### PR TITLE
Fix center content responsive width

### DIFF
--- a/src/components/DiscoveryApp/DiscoveryApp.css
+++ b/src/components/DiscoveryApp/DiscoveryApp.css
@@ -43,26 +43,37 @@ button:focus {
   width: 100vw;
   height: 100vh;
 
-  & .inner-container {
+  > #left-nav {
+    width: var(--left-nav-width);
+    padding-top: var(--top-header-height);
+  }
+
+  > .inner-container {
     margin-top: 56px;
+    width: calc(100vw - var(--left-nav-width) - var(--right-details-width));
 
-    & #below-timeline {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
+    > .standard-filters {
+      width: 100%;
+    }
 
-      & #left-nav {
-        width: var(--left-nav-width);
+    > #below-timeline {
+      padding: 8px;
+
+      > #measure-available-width {
+        width: 100%;
       }
 
-      & main {
-        flex: auto;
-        padding: 8px;
+      > main {
+        & .collections-content {
+          width: calc(100vw - var(--left-nav-width) - var(--right-details-width) - 16px);
+          height: calc(100vh - 260px);
+          overflow: scroll;
+        }
       }
     }
   }
 
-  & #details-right {
+  > #details-right {
     width: var(--right-details-width);
     min-width: var(--right-details-width);
     margin-top: var(--top-header-height);

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -207,6 +207,7 @@ export default class DiscoveryApp extends React.PureComponent {
             participantId={participantId}
           />
           <div className="outer-container">
+            <div id="left-nav" style={{ display: isSummary ? 'none' : 'block' }} />
             <div className="inner-container">
               <div className="standard-filters" style={{ display: isSummary ? 'none' : 'block' }}>
                 <StandardFilters
@@ -227,7 +228,7 @@ export default class DiscoveryApp extends React.PureComponent {
                 />
               </div>
               <div id="below-timeline">
-                { !isSummary && <div id="left-nav" /> }
+                <div id="measure-available-width">  </div>
                 <main>
                   { this.state.resources && (
                     <Switch>

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -197,6 +197,8 @@ export default class DiscoveryApp extends React.PureComponent {
 
     const { match: { params: { activeView = 'summary', participantId } } } = this.props;
 
+    const isSummary = activeView === 'summary';
+
     return (
       <DiscoveryContext.Provider value={this.state}>
         { this.state.themeName && <link rel="stylesheet" type="text/css" href={`/themes/${this.state.themeName}.css`} /> }
@@ -206,7 +208,7 @@ export default class DiscoveryApp extends React.PureComponent {
           />
           <div className="outer-container">
             <div className="inner-container">
-              <div className="standard-filters">
+              <div className="standard-filters" style={{ display: isSummary ? 'none' : 'block' }}>
                 <StandardFilters
                   activeView={activeView}
                   resources={this.state.resources}
@@ -225,7 +227,7 @@ export default class DiscoveryApp extends React.PureComponent {
                 />
               </div>
               <div id="below-timeline">
-                <div id="left-nav" />
+                { !isSummary && <div id="left-nav" /> }
                 <main>
                   { this.state.resources && (
                     <Switch>
@@ -304,7 +306,7 @@ export default class DiscoveryApp extends React.PureComponent {
                 </main>
               </div>
             </div>
-            <div id="details-right" />
+            { !isSummary && <div id="details-right" /> }
           </div>
           <PageFooter resources={this.state.resources} />
         </div>

--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -42,11 +42,6 @@ const PageHeader = ({ participantId }) => (
         Compare
       </NavLink>
       <NavLink
-        to={`/participant/${participantId}/timeline`}
-      >
-        Timeline
-      </NavLink>
-      <NavLink
         to={`/participant/${participantId}/collections`}
       >
         Collections

--- a/src/components/StandardFilters/StandardFilters.css
+++ b/src/components/StandardFilters/StandardFilters.css
@@ -6,29 +6,6 @@
 
 /* v.01.05 Updated 08/21/2019 */
 
-.standard-filters {
-  width: calc(100vw - var(--right-details-width));
-  /*    position: fixed;
-    top: 46px;
-    left: -150px;
-    height: 100%;
-    width: 100%; */
-}
-
-#measure-available-width {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-
-  > #measure-leftnav-width {
-    width: var(--left-nav-width);
-  }
-
-  > #measure-timeline-width {
-    width: calc(100vw - var(--left-nav-width) - var(--right-details-width));
-  }
-}
-
 .standard-filters-categories-and-providers {
   /* lower/main timeline */
 

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -150,7 +150,7 @@ class StandardFilters extends React.PureComponent {
     const leftnavWidth = checkQuerySelector('#measure-leftnav-width');
 
     if (availableWidth && leftnavWidth) {
-      const svgWidth = availableWidth.getBoundingClientRect().width - leftnavWidth.getBoundingClientRect().width - 13; // TODO: fix (far-right margin)
+      const svgWidth = availableWidth.getBoundingClientRect().width - leftnavWidth.getBoundingClientRect().width; // TODO: fix (far-right margin)
       this.setState({ svgWidth: `${svgWidth}px` });
     }
   }

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -146,12 +146,10 @@ class StandardFilters extends React.PureComponent {
 
   // Kluge: following needs to know about lower-level classes
   updateSvgWidth = (event) => {
-    const availableWidth = checkQuerySelector('#measure-available-width');
-    const leftnavWidth = checkQuerySelector('#measure-leftnav-width');
-
-    if (availableWidth && leftnavWidth) {
-      const svgWidth = availableWidth.getBoundingClientRect().width - leftnavWidth.getBoundingClientRect().width; // TODO: fix (far-right margin)
-      this.setState({ svgWidth: `${svgWidth}px` });
+    const availableWidthEl = checkQuerySelector('#measure-available-width');
+    if (availableWidthEl) {
+      const availableWidth = availableWidthEl.getBoundingClientRect().width;
+      this.setState({ svgWidth: `${availableWidth}px` });
     }
   }
 
@@ -676,10 +674,6 @@ class StandardFilters extends React.PureComponent {
           dotPositionsFn={this.fetchDotPositions}
           dotClickFn={dotClickFn}
         />
-        <div id="measure-available-width">
-          <div id="measure-leftnav-width" />
-          <div id="measure-timeline-width" />
-        </div>
         { this.portalLeftNav() }
       </>
     );

--- a/src/components/TimeWidget/TimeWidget.css
+++ b/src/components/TimeWidget/TimeWidget.css
@@ -96,6 +96,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  /* originally: min-width: 810px; */
   height: 100px;
   max-height: 100px;
   background-color: transparent;

--- a/src/components/TimeWidget/index.js
+++ b/src/components/TimeWidget/index.js
@@ -367,10 +367,7 @@ export default class TimeWidget extends React.Component {
     const rightGradientWidth = numericPart(this.props.timelineWidth) - this.state.rightX;
 
     return (
-      <div className="time-widget">
-        <div className="participant-name">
-          { this.context.resources && formatPatientName(this.context.resources.pathItem('[category=Patient].data.name')) }
-        </div>
+      <div className="time-widget" style={{ width: this.props.timelineWidth }}>
         <div className="timeline-controls">
           <div className="timeline-tbd-container">
             <div className="timeline-selector-gradient-container">


### PR DESCRIPTION
* `TimeWidget` has been moved to _above_ the main, center content area, rather than above the combined left-nav + content area

* The responsiveness of the width of the main center content area has been fixed, for the Catalog view
 
* The timeline and left-nav are no longer visible on the Summary view

* NOTE: patient name is removed, because it was being rendered _in_ `TimeWidget`, complicating the layout



![image](https://user-images.githubusercontent.com/3383704/105079073-e5926600-5a5c-11eb-8770-5cbf4aea2db9.png)
