### PR TITLE
Records as dictionary

### DIFF
--- a/src/components/Collections/index.js
+++ b/src/components/Collections/index.js
@@ -5,7 +5,9 @@ import { allRecordIds, connectToResources } from '../../recoil';
 import PersistentDrawerRight from '../ContentPanel/Drawer';
 import RecordCard from '../cards/RecordCard';
 
-const CardList = ({ normalized, patient }) => {
+const CardList = ({
+  recordIds, records, normalized, patient,
+}) => {
   if (!normalized) {
     return null;
   }
@@ -14,10 +16,10 @@ const CardList = ({ normalized, patient }) => {
   // const record = normalized.filter(element => element.data.id === '4afef915-ade7-42d4-8e82-5012e1c47704')
   // return record.map((r, i) => <RecordCard key={i} resource={r} normalized={normalized} />);
 
-  return normalized.map((r) => (
+  return recordIds.map((uuid) => (
     <RecordCard
-      key={`record-card-${r.data.id}`}
-      resource={r}
+      key={`record-card-${uuid}`}
+      resource={records[uuid]}
       records={normalized}
       patient={patient}
     />
@@ -29,7 +31,7 @@ const Collections = (props) => {
   // console.info('recordIds: ', recordIds);
 
   const {
-    loading, normalized, patient,
+    loading, records, normalized, patient,
   } = props.resources;
 
   return (
@@ -48,6 +50,8 @@ const Collections = (props) => {
         <div className="card-list">
           <CardList
             normalized={normalized}
+            recordIds={allRecordIds}
+            records={records}
             patient={patient}
           />
         </div>

--- a/src/components/Collections/index.js
+++ b/src/components/Collections/index.js
@@ -17,7 +17,7 @@ const CardList = ({ normalized, patient }) => {
     <RecordCard
       key={`record-card-${r.data.id}`}
       resource={r}
-      normalized={normalized}
+      records={normalized}
       patient={patient}
     />
   ));

--- a/src/components/Collections/index.js
+++ b/src/components/Collections/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { connectToResources } from '../../recoil';
+import { useRecoilValue } from 'recoil';
+import { allRecordIdsState, connectToResources } from '../../recoil';
 import PersistentDrawerRight from '../ContentPanel/Drawer';
 import RecordCard from '../cards/RecordCard';
 
@@ -24,6 +25,9 @@ const CardList = ({ normalized, patient }) => {
 };
 
 const Collections = (props) => {
+  const allRecordIds = useRecoilValue(allRecordIdsState);
+  // console.info('allRecordIds: ', allRecordIds);
+
   const {
     loading, normalized, patient,
   } = props.resources;

--- a/src/components/Collections/index.js
+++ b/src/components/Collections/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useRecoilValue } from 'recoil';
-import { allRecordIdsState, connectToResources } from '../../recoil';
+import { allRecordIds, connectToResources } from '../../recoil';
 import PersistentDrawerRight from '../ContentPanel/Drawer';
 import RecordCard from '../cards/RecordCard';
 
@@ -25,8 +25,8 @@ const CardList = ({ normalized, patient }) => {
 };
 
 const Collections = (props) => {
-  const allRecordIds = useRecoilValue(allRecordIdsState);
-  // console.info('allRecordIds: ', allRecordIds);
+  const recordIds = useRecoilValue(allRecordIds);
+  // console.info('recordIds: ', recordIds);
 
   const {
     loading, normalized, patient,

--- a/src/components/Collections/index.js
+++ b/src/components/Collections/index.js
@@ -6,32 +6,22 @@ import PersistentDrawerRight from '../ContentPanel/Drawer';
 import RecordCard from '../cards/RecordCard';
 
 const CardList = ({
-  recordIds, records, normalized, patient,
-}) => {
-  if (!normalized) {
-    return null;
-  }
-
-  // const record = normalized.filter((element) => element.category === 'Lab Results');
-  // const record = normalized.filter(element => element.data.id === '4afef915-ade7-42d4-8e82-5012e1c47704')
-  // return record.map((r, i) => <RecordCard key={i} resource={r} normalized={normalized} />);
-
-  return recordIds.map((uuid) => (
-    <RecordCard
-      key={`record-card-${uuid}`}
-      resource={records[uuid]}
-      records={normalized}
-      patient={patient}
-    />
-  ));
-};
+  recordIds, records, patient,
+}) => recordIds.map((uuid) => (
+  <RecordCard
+    key={`record-card-${uuid}`}
+    recordId={uuid}
+    records={records}
+    patient={patient}
+  />
+));
 
 const Collections = (props) => {
   const recordIds = useRecoilValue(allRecordIds);
   // console.info('recordIds: ', recordIds);
 
   const {
-    loading, records, normalized, patient,
+    loading, records, patient,
   } = props.resources;
 
   return (
@@ -42,15 +32,19 @@ const Collections = (props) => {
         { String(loading) }
       </div>
       <div className="collections-content">
+        <h4>patient:</h4>
         <pre>
-          { JSON.stringify(normalized, null, '  ') }
+          { JSON.stringify(patient, null, '  ') }
+        </pre>
+        <h4>records:</h4>
+        <pre>
+          { JSON.stringify(records, null, '  ') }
         </pre>
       </div>
       <PersistentDrawerRight>
         <div className="card-list">
           <CardList
-            normalized={normalized}
-            recordIds={allRecordIds}
+            recordIds={recordIds}
             records={records}
             patient={patient}
           />

--- a/src/components/Collections/index.js
+++ b/src/components/Collections/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useRecoilValue } from 'recoil';
-import { allRecordIds, resourcesState } from '../../recoil';
+import { allRecordIds, resourcesState, patientRecord } from '../../recoil';
 import PersistentDrawerRight from '../ContentPanel/Drawer';
 import RecordCard from '../cards/RecordCard';
 
@@ -19,9 +19,10 @@ const CardList = ({
 const Collections = () => {
   const recordIds = useRecoilValue(allRecordIds);
   const resources = useRecoilValue(resourcesState);
+  const patient = useRecoilValue(patientRecord);
 
   const {
-    loading, records, patient,
+    loading, records,
   } = resources;
 
   return (

--- a/src/components/Collections/index.js
+++ b/src/components/Collections/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useRecoilValue } from 'recoil';
-import { allRecordIds, connectToResources } from '../../recoil';
+import { allRecordIds, resourcesState } from '../../recoil';
 import PersistentDrawerRight from '../ContentPanel/Drawer';
 import RecordCard from '../cards/RecordCard';
 
@@ -16,13 +16,13 @@ const CardList = ({
   />
 ));
 
-const Collections = (props) => {
+const Collections = () => {
   const recordIds = useRecoilValue(allRecordIds);
-  // console.info('recordIds: ', recordIds);
+  const resources = useRecoilValue(resourcesState);
 
   const {
     loading, records, patient,
-  } = props.resources;
+  } = resources;
 
   return (
     <div>
@@ -54,4 +54,4 @@ const Collections = (props) => {
   );
 };
 
-export default connectToResources(Collections);
+export default React.memo(Collections);

--- a/src/components/ContentPanel/ContentRight.js
+++ b/src/components/ContentPanel/ContentRight.js
@@ -38,6 +38,7 @@ import Unimplemented from '../Unimplemented';
 
 import DiscoveryContext from '../DiscoveryContext';
 import PersistentDrawerRight from './Drawer';
+import { patientRecord } from '../../recoil';
 
 //
 // Render the content panel for ReportView, FinancialView, TilesView
@@ -745,11 +746,13 @@ class ContentPanel extends React.PureComponent {
 
 const ContentPanelHOC = React.memo((props) => {
   const dotClickContext = useRecoilValue(dotClickContextState);
+  const patient = useRecoilValue(patientRecord);
 
   return (
     <ContentPanel
       {...props} // eslint-disable-line react/jsx-props-no-spreading
       context={dotClickContext}
+      patient={patient}
     />
   );
 });

--- a/src/components/DiscoveryApp/Api.js
+++ b/src/components/DiscoveryApp/Api.js
@@ -261,32 +261,32 @@ export const computeFilterState = (legacyResources) => {
 
 // Return sorted array of all provider names for this participant
 export const extractProviders = (normalized) => {
-  const provs = {};
+  const providersSet = new Set();
   if (normalized) {
     for (const resource of normalized) {
       // Add the found provider
-      provs[resource.provider] = null;
+      providersSet.add(resource.provider);
     }
   }
-  return Object.keys(provs).sort();
+  return [...providersSet].sort();
 };
 
 // Return sorted array of all populated category names for this participant
 export const extractCategories = (normalized) => {
   // const { legacy: legacyResources } = this.props.resources;
-  const cats = {};
+  const categoriesSet = new Set();
   if (normalized) {
     for (const resource of normalized) {
       if (resource.category === 'Patient') {
         // Ignore
       } else if (Unimplemented.unimplementedCats.includes(resource.category)) {
         // Add the "Unimplemented" category
-        cats[Unimplemented.catName] = null;
+        categoriesSet.add(Unimplemented.catName);
       } else {
         // Add the found category
-        cats[resource.category] = null;
+        categoriesSet.add(resource.category);
       }
     }
   }
-  return Object.keys(cats).sort();
+  return [...categoriesSet].sort();
 };

--- a/src/components/DiscoveryApp/Api.js
+++ b/src/components/DiscoveryApp/Api.js
@@ -225,6 +225,18 @@ export const normalizeResourcesAndInjectPartipantId = (participantId) => (data) 
   return result;
 };
 
+export const generateRecordsDictionary = (normalized) => normalized.reduce((acc, record) => {
+  const { data: { id: uuid } } = record;
+  // console.info('uuid: ', uuid);
+  if (acc[uuid]) {
+    console.info(`record ${uuid} already exists. (category = ${record.category})`); // eslint-disable-line no-console
+  }
+  return {
+    ...acc,
+    [uuid]: record,
+  };
+}, {});
+
 export const generateLegacyResources = (rawResponseData, normalizedResources, participantId) => {
   const legacyResources = new FhirTransform(normalizedResources);
   // const resources = (response.data, this.participantId);

--- a/src/components/DiscoveryApp/Api.js
+++ b/src/components/DiscoveryApp/Api.js
@@ -260,31 +260,33 @@ export const computeFilterState = (legacyResources) => {
 };
 
 // Return sorted array of all provider names for this participant
-export const extractProviders = (normalized) => {
+export const extractProviders = (records) => {
   const providersSet = new Set();
-  if (normalized) {
-    for (const resource of normalized) {
+  if (records) {
+    for (const key in records) {
+      const record = records[key];
       // Add the found provider
-      providersSet.add(resource.provider);
+      providersSet.add(record.provider);
     }
   }
   return [...providersSet].sort();
 };
 
 // Return sorted array of all populated category names for this participant
-export const extractCategories = (normalized) => {
+export const extractCategories = (records) => {
   // const { legacy: legacyResources } = this.props.resources;
   const categoriesSet = new Set();
-  if (normalized) {
-    for (const resource of normalized) {
-      if (resource.category === 'Patient') {
+  if (records) {
+    for (const key in records) {
+      const record = records[key];
+      if (record.category === 'Patient') {
         // Ignore
-      } else if (Unimplemented.unimplementedCats.includes(resource.category)) {
+      } else if (Unimplemented.unimplementedCats.includes(record.category)) {
         // Add the "Unimplemented" category
         categoriesSet.add(Unimplemented.catName);
       } else {
         // Add the found category
-        categoriesSet.add(resource.category);
+        categoriesSet.add(record.category);
       }
     }
   }

--- a/src/components/DiscoveryApp/Api.js
+++ b/src/components/DiscoveryApp/Api.js
@@ -193,6 +193,7 @@ export const normalizeResourcesAndInjectPartipantId = (participantId) => (data) 
   const result = [];
   for (const providerName in data) {
     if (data[providerName].error) {
+      console.error('data[providerName].error: ', data[providerName].error); // eslint-disable-line no-console
       // Error response
       if (!result.Error) {
         // Init container

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -142,7 +142,7 @@ class DiscoveryApp extends React.PureComponent {
     const { dates, thumbLeftDate, thumbRightDate } = filters;
 
     const {
-      patient, totalResCount, providers, categories,
+      totalResCount, providers, categories,
     } = resources;
 
     return (
@@ -227,7 +227,6 @@ class DiscoveryApp extends React.PureComponent {
                           thumbLeftDate={thumbLeftDate}
                           thumbRightDate={thumbRightDate}
                           resources={legacyResources}
-                          patient={patient}
                           providers={providers}
                           totalResCount={totalResCount}
                           viewName="Report"
@@ -287,8 +286,6 @@ const DiscoveryAppHOC = (props) => {
           throw new Error('Invalid Participant ID');
         }
         const legacy = generateLegacyResources(raw, normalized, participantId);
-        // const patient = legacy.pathItem('[category=Patient]');
-        const patient = normalized.find(({ category }) => category === 'Patient');
         const totalResCount = legacy.transformed.filter((elt) => elt.category !== 'Patient').length;
         const records = generateRecordsDictionary(normalized);
         const providers = extractProviders(records);
@@ -300,7 +297,6 @@ const DiscoveryAppHOC = (props) => {
           normalized,
           records,
           totalResCount,
-          patient,
           providers,
           categories,
           legacy,

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -16,7 +16,7 @@ import TilesView from '../TilesView';
 import Collections from '../Collections';
 import PageFooter from '../PageFooter';
 import {
-  normalizeResourcesAndInjectPartipantId, generateLegacyResources, computeFilterState, extractProviders, extractCategories,
+  normalizeResourcesAndInjectPartipantId, generateRecordsDictionary, generateLegacyResources, computeFilterState, extractProviders, extractCategories,
 } from './Api';
 import {
   resourcesState, filtersState, activeCategoriesState, activeProvidersState,
@@ -290,17 +290,7 @@ const DiscoveryAppHOC = (props) => {
         // const patient = legacy.pathItem('[category=Patient]');
         const patient = normalized.find(({ category }) => category === 'Patient');
         const totalResCount = legacy.transformed.filter((elt) => elt.category !== 'Patient').length;
-        const records = normalized.reduce((acc, record) => {
-          const { data: { id: uuid } } = record;
-          // console.info('uuid: ', uuid);
-          if (acc[uuid]) {
-            console.info(`record ${uuid} already exists. (category = ${record.category})`); // eslint-disable-line no-console
-          }
-          return {
-            ...acc,
-            [uuid]: record,
-          };
-        }, {});
+        const records = generateRecordsDictionary(normalized);
         const providers = extractProviders(records);
         const categories = extractCategories(records);
 

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -287,14 +287,15 @@ const DiscoveryAppHOC = (props) => {
         }
         const legacy = generateLegacyResources(raw, normalized, participantId);
         const totalResCount = legacy.transformed.filter((elt) => elt.category !== 'Patient').length;
+        // TODO: records (as dictionary) could be built direcetly, without intersitial "normalized" ?
         const records = generateRecordsDictionary(normalized);
+        // TODO: should providers and categories be dedicated recoil states, derived from "records" ?
         const providers = extractProviders(records);
         const categories = extractCategories(records);
 
         setResources({
           ...resources,
           raw,
-          normalized,
           records,
           totalResCount,
           providers,

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -292,11 +292,23 @@ const DiscoveryAppHOC = (props) => {
         const providers = extractProviders(normalized);
         const categories = extractCategories(normalized);
         const totalResCount = legacy.transformed.filter((elt) => elt.category !== 'Patient').length;
+        const records = normalized.reduce((acc, record) => {
+          const { data: { id: uuid } } = record;
+          // console.info('uuid: ', uuid);
+          if (acc[uuid]) {
+            console.info(`record ${uuid} already exists. (category = ${record.category})`); // eslint-disable-line no-console
+          }
+          return {
+            ...acc,
+            [uuid]: record,
+          };
+        }, {});
 
         setResources({
           ...resources,
           raw,
           normalized,
+          records,
           totalResCount,
           patient,
           providers,

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -289,8 +289,6 @@ const DiscoveryAppHOC = (props) => {
         const legacy = generateLegacyResources(raw, normalized, participantId);
         // const patient = legacy.pathItem('[category=Patient]');
         const patient = normalized.find(({ category }) => category === 'Patient');
-        const providers = extractProviders(normalized);
-        const categories = extractCategories(normalized);
         const totalResCount = legacy.transformed.filter((elt) => elt.category !== 'Patient').length;
         const records = normalized.reduce((acc, record) => {
           const { data: { id: uuid } } = record;
@@ -303,6 +301,8 @@ const DiscoveryAppHOC = (props) => {
             [uuid]: record,
           };
         }, {});
+        const providers = extractProviders(records);
+        const categories = extractCategories(records);
 
         setResources({
           ...resources,

--- a/src/components/Immunizations/index.js
+++ b/src/components/Immunizations/index.js
@@ -8,12 +8,11 @@ import { renderImmunizations, primaryTextValue } from '../../fhirUtil.js';
 import {
   Const, stringCompare, formatKey, formatContentHeader,
 } from '../../util.js';
-import { connectToResources } from '../../recoil';
 
 //
 // Display the 'Immunizations' category if there are matching resources
 //
-class Immunizations extends React.Component {
+export default class Immunizations extends React.Component {
   static catName = 'Immunizations';
 
   static compareFn(a, b) {
@@ -75,5 +74,3 @@ class Immunizations extends React.Component {
       ));
   }
 }
-
-export default connectToResources(Immunizations);

--- a/src/components/cards/LabResultCardBody.js
+++ b/src/components/cards/LabResultCardBody.js
@@ -2,9 +2,11 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 
+import { useRecoilValue } from 'recoil';
 import CardBodyField from './CardBodyField';
 import TimeSeries from '../TimeSeries/index';
 import { computeTimeSeriesLabResultsData } from '../../fhirUtil';
+import { labResultRecords } from '../../recoil';
 
 const useStyles = makeStyles(() => ({
   timeSeries: {
@@ -12,7 +14,8 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const LabResultCardBody = ({ fieldsData, labResults }) => {
+const LabResultCardBody = ({ fieldsData }) => {
+  const labResults = useRecoilValue(labResultRecords);
   const classes = useStyles();
   const valueRatioDisplay = `${fieldsData.valueRatio?.numerator?.value} / ${fieldsData.valueRatio?.denominator?.value}`;
 

--- a/src/components/cards/RecordCard.js
+++ b/src/components/cards/RecordCard.js
@@ -207,4 +207,4 @@ RecordCard.prototype = {
   patient: shape({}).isRequired,
 };
 
-export default RecordCard;
+export default React.memo(RecordCard);

--- a/src/components/cards/RecordCard.js
+++ b/src/components/cards/RecordCard.js
@@ -11,7 +11,6 @@ import Collapse from '@material-ui/core/Collapse';
 import TextField from '@material-ui/core/TextField';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { format } from 'date-fns';
-import jsonQuery from 'json-query';
 
 import GenericCardBody from './GenericCardBody';
 import MedicationCardBody from './MedicationCardBody';
@@ -27,7 +26,7 @@ import UnimplementedCardBody from './UnimplementedCardBody';
 import VitalSignCardBody from './VitalSignCardBody';
 import { formatAge } from '../../util';
 
-const selectCardBody = (fieldsData, records) => {
+const selectCardBody = (fieldsData) => {
   switch (fieldsData.category) {
     case 'Conditions':
     case 'Document References':
@@ -47,8 +46,7 @@ const selectCardBody = (fieldsData, records) => {
     case 'Immunizations':
       return <ImmunizationCardBody fieldsData={fieldsData} />;
     case 'Lab Results':
-      const labResults = jsonQuery('[*category=Lab Results]', { data: records }).value;
-      return <LabResultCardBody fieldsData={fieldsData} labResults={labResults} />;
+      return <LabResultCardBody fieldsData={fieldsData} />;
     case 'Exams':
       return <ExamCardBody fieldsData={fieldsData} />;
     case 'Meds Statement':
@@ -58,8 +56,7 @@ const selectCardBody = (fieldsData, records) => {
     case 'Other':
       return <UnimplementedCardBody fieldsData={fieldsData} />;
     case 'Vital Signs':
-      const vitalSigns = jsonQuery('[*category=Vital Signs]', { data: records }).value;
-      return <VitalSignCardBody fieldsData={fieldsData} vitalSigns={vitalSigns} />;
+      return <VitalSignCardBody fieldsData={fieldsData} />;
     default:
       break;
   }
@@ -91,11 +88,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const RecordCard = ({ recordId, records, patient }) => {
+const RecordCard = ({
+  recordId, records, patient,
+}) => {
   const [expanded, setExpanded] = React.useState(false);
   const classes = useStyles();
 
-  console.info('recordId, records, patient:', recordId, records, patient);
+  // console.info('recordId, records, patient:', recordId, records, patient);
   const record = records[recordId];
 
   const {

--- a/src/components/cards/RecordCard.js
+++ b/src/components/cards/RecordCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { shape } from 'prop-types';
+import { string, shape } from 'prop-types';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
@@ -91,12 +91,16 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const RecordCard = ({ resource, records, patient }) => {
+const RecordCard = ({ recordId, records, patient }) => {
   const [expanded, setExpanded] = React.useState(false);
   const classes = useStyles();
+
+  console.info('recordId, records, patient:', recordId, records, patient);
+  const record = records[recordId];
+
   const {
     provider, data, itemDate, category,
-  } = resource;
+  } = record;
 
   const displayDate = format(new Date(itemDate), 'MMM d, y h:mm:ssaaa');
 
@@ -104,14 +108,14 @@ const RecordCard = ({ resource, records, patient }) => {
     abatement: data.abatementDateTime,
     asserted: data.assertedDate,
     billablePeriod: data.billablePeriod,
-    category: resource.category,
+    category: record.category,
     careTeam: data.careTeam,
     class: data.class?.code,
     clinicalStatus: data.clinicalStatus,
     criticality: data.criticality,
     component: data.component,
     contained: data.contained,
-    date: resource.itemDate,
+    date: record.itemDate,
     daysSupply: data.daysSupply,
     diagnosis: data.diagnosis?.[0]?.type?.[0]?.coding?.[0]?.code,
     display: data.code?.text,
@@ -121,7 +125,7 @@ const RecordCard = ({ resource, records, patient }) => {
     notGiven: data.notGiven,
     onset: data.onsetDateTime,
     orderedBy: data.orderer?.display,
-    participantId: resource.id,
+    participantId: record.id,
     period: data.period,
     primarySource: data.primarySource,
     provider,
@@ -150,7 +154,7 @@ const RecordCard = ({ resource, records, patient }) => {
 
   // console.log('fieldsData', fieldsData)
 
-  const patientAgeAtRecord = formatAge(patient.data.birthDate, resource.itemDate, 'age ') || '';
+  const patientAgeAtRecord = formatAge(patient.data.birthDate, record.itemDate, 'age ') || '';
 
   return (
     <Card
@@ -199,7 +203,9 @@ const RecordCard = ({ resource, records, patient }) => {
 };
 
 RecordCard.prototype = {
-  resource: shape({}),
+  recordId: string.isRequired,
+  records: shape({}).isRequired,
+  patient: shape({}).isRequired,
 };
 
 export default RecordCard;

--- a/src/components/cards/RecordCard.js
+++ b/src/components/cards/RecordCard.js
@@ -27,7 +27,7 @@ import UnimplementedCardBody from './UnimplementedCardBody';
 import VitalSignCardBody from './VitalSignCardBody';
 import { formatAge } from '../../util';
 
-const selectCardBody = (fieldsData, normalized) => {
+const selectCardBody = (fieldsData, records) => {
   switch (fieldsData.category) {
     case 'Conditions':
     case 'Document References':
@@ -47,7 +47,7 @@ const selectCardBody = (fieldsData, normalized) => {
     case 'Immunizations':
       return <ImmunizationCardBody fieldsData={fieldsData} />;
     case 'Lab Results':
-      const labResults = jsonQuery('[*category=Lab Results]', { data: normalized }).value;
+      const labResults = jsonQuery('[*category=Lab Results]', { data: records }).value;
       return <LabResultCardBody fieldsData={fieldsData} labResults={labResults} />;
     case 'Exams':
       return <ExamCardBody fieldsData={fieldsData} />;
@@ -58,7 +58,7 @@ const selectCardBody = (fieldsData, normalized) => {
     case 'Other':
       return <UnimplementedCardBody fieldsData={fieldsData} />;
     case 'Vital Signs':
-      const vitalSigns = jsonQuery('[*category=Vital Signs]', { data: normalized }).value;
+      const vitalSigns = jsonQuery('[*category=Vital Signs]', { data: records }).value;
       return <VitalSignCardBody fieldsData={fieldsData} vitalSigns={vitalSigns} />;
     default:
       break;
@@ -91,7 +91,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const RecordCard = ({ resource, normalized, patient }) => {
+const RecordCard = ({ resource, records, patient }) => {
   const [expanded, setExpanded] = React.useState(false);
   const classes = useStyles();
   const {
@@ -171,7 +171,7 @@ const RecordCard = ({ resource, normalized, patient }) => {
       />
       <CardContent>
         <Grid container spacing={0}>
-          {selectCardBody(fieldsData, normalized)}
+          {selectCardBody(fieldsData, records)}
         </Grid>
       </CardContent>
       <CardActions disableSpacing className={classes.cardActions}>

--- a/src/components/cards/VitalSignCardBody.js
+++ b/src/components/cards/VitalSignCardBody.js
@@ -2,9 +2,11 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 
+import { useRecoilValue } from 'recoil';
 import CardBodyField from './CardBodyField';
 import TimeSeries from '../TimeSeries/index';
 import { computeTimeSeriesVitalSignsData } from '../../fhirUtil';
+import { vitalSignsRecords } from '../../recoil';
 
 const useStyles = makeStyles(() => ({
   timeSeries: {
@@ -12,7 +14,8 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const VitalSignCardBody = ({ fieldsData, vitalSigns }) => {
+const VitalSignCardBody = ({ fieldsData }) => {
+  const vitalSigns = useRecoilValue(vitalSignsRecords);
   const classes = useStyles();
   const valueDisplay = fieldsData.valueQuantity && `${fieldsData.valueQuantity.value.toFixed(1)} ${fieldsData.valueQuantity.unit}`;
 

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -12,6 +12,7 @@ export const resourcesState = atom({
     error: null,
     raw: null,
     normalized: null,
+    records: {},
     totalResCount: 0,
     patient: null,
     providers: [],

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  atom, useRecoilValue,
+  atom, selector, useRecoilValue,
 } from 'recoil';
 
 export * from './category-provider-filters';
@@ -28,6 +28,21 @@ export const filtersState = atom({
     dates: null,
     thumbLeftDate: null,
     thumbRightDate: null,
+  },
+});
+
+export const allRecordIdsState = selector({
+  key: 'allRecordIdsState',
+  get: ({ get }) => {
+    const { records } = get(resourcesState);
+    // Return all record ids as an Array:
+    return Object.entries(records).reduce((acc, [uuid, record]) => {
+      if (record.category === 'Patient') {
+        console.info(`IGNORE PATIENT ${uuid}`); // eslint-disable-line no-console
+      }
+      acc.push(uuid);
+      return acc;
+    }, []);
   },
 });
 

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -47,12 +47,19 @@ export const allRecordIds = selector({
   },
 });
 
+// export const patientRecord = selector({
+//   key: 'patientRecord',
+//   get: ({ get }) => {
+//     const { normalized } = get(resourcesState);
+//     return normalized.find(({ category }) => category === 'Patient');
+//   },
+// });
+
 export const labResultRecords = selector({
   key: 'labResultRecords',
   get: ({ get }) => {
     const { normalized } = get(resourcesState);
-    const labResults = jsonQuery('[*category=Lab Results]', { data: normalized }).value;
-    return labResults;
+    return jsonQuery('[*category=Lab Results]', { data: normalized }).value;
   },
 });
 
@@ -60,8 +67,7 @@ export const vitalSignsRecords = selector({
   key: 'vitalSignsRecords',
   get: ({ get }) => {
     const { normalized } = get(resourcesState);
-    const vitalSigns = jsonQuery('[*category=Vital Signs]', { data: normalized }).value;
-    return vitalSigns;
+    return jsonQuery('[*category=Vital Signs]', { data: normalized }).value;
   },
 });
 

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -31,8 +31,8 @@ export const filtersState = atom({
   },
 });
 
-export const allRecordIdsState = selector({
-  key: 'allRecordIdsState',
+export const allRecordIds = selector({
+  key: 'allRecordIds',
   get: ({ get }) => {
     const { records } = get(resourcesState);
     // Return all record ids as an Array:

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -11,7 +11,6 @@ export const resourcesState = atom({
     loading: false,
     error: null,
     raw: null,
-    normalized: null,
     records: {},
     totalResCount: 0,
     providers: [],
@@ -48,24 +47,24 @@ export const allRecordIds = selector({
 export const patientRecord = selector({
   key: 'patientRecord',
   get: ({ get }) => {
-    const { normalized } = get(resourcesState);
-    return normalized.find(({ category }) => category === 'Patient');
+    const { records } = get(resourcesState);
+    return Object.values(records).find(({ category }) => category === 'Patient');
   },
 });
 
 export const labResultRecords = selector({
   key: 'labResultRecords',
   get: ({ get }) => {
-    const { normalized } = get(resourcesState);
-    return jsonQuery('[*category=Lab Results]', { data: normalized }).value;
+    const { records } = get(resourcesState);
+    return jsonQuery('[*category=Lab Results]', { data: Object.values(records) }).value;
   },
 });
 
 export const vitalSignsRecords = selector({
   key: 'vitalSignsRecords',
   get: ({ get }) => {
-    const { normalized } = get(resourcesState);
-    return jsonQuery('[*category=Vital Signs]', { data: normalized }).value;
+    const { records } = get(resourcesState);
+    return jsonQuery('[*category=Vital Signs]', { data: Object.values(records) }).value;
   },
 });
 

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -14,7 +14,6 @@ export const resourcesState = atom({
     normalized: null,
     records: {},
     totalResCount: 0,
-    patient: null,
     providers: [],
     categories: [],
     legacy: null,
@@ -46,13 +45,13 @@ export const allRecordIds = selector({
   },
 });
 
-// export const patientRecord = selector({
-//   key: 'patientRecord',
-//   get: ({ get }) => {
-//     const { normalized } = get(resourcesState);
-//     return normalized.find(({ category }) => category === 'Patient');
-//   },
-// });
+export const patientRecord = selector({
+  key: 'patientRecord',
+  get: ({ get }) => {
+    const { normalized } = get(resourcesState);
+    return normalized.find(({ category }) => category === 'Patient');
+  },
+});
 
 export const labResultRecords = selector({
   key: 'labResultRecords',

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -1,6 +1,5 @@
-import React from 'react';
 import {
-  atom, selector, useRecoilValue,
+  atom, selector,
 } from 'recoil';
 import jsonQuery from 'json-query';
 
@@ -81,20 +80,3 @@ export const vitalSignsRecords = selector({
 //     },
 //   },
 // });
-
-// read-only connection to resources and filters:
-export const connectToResources = (Component) => (props) => {
-  const resources = useRecoilValue(resourcesState);
-  const filters = useRecoilValue(filtersState);
-  // const vitalSigns = useRecoilValue(vitalSignsRecords);
-  // const labResults = useRecoilValue(labResultRecords);
-  // useContext(DiscoveryContext);
-
-  return (
-    <Component
-      {...props} // eslint-disable-line react/jsx-props-no-spreading
-      resources={resources}
-      filters={filters}
-    />
-  );
-};

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   atom, selector, useRecoilValue,
 } from 'recoil';
+import jsonQuery from 'json-query';
 
 export * from './category-provider-filters';
 
@@ -46,6 +47,24 @@ export const allRecordIds = selector({
   },
 });
 
+export const labResultRecords = selector({
+  key: 'labResultRecords',
+  get: ({ get }) => {
+    const { normalized } = get(resourcesState);
+    const labResults = jsonQuery('[*category=Lab Results]', { data: normalized }).value;
+    return labResults;
+  },
+});
+
+export const vitalSignsRecords = selector({
+  key: 'vitalSignsRecords',
+  get: ({ get }) => {
+    const { normalized } = get(resourcesState);
+    const vitalSigns = jsonQuery('[*category=Vital Signs]', { data: normalized }).value;
+    return vitalSigns;
+  },
+});
+
 // TODO: ^other states facilitate implementation of something like the following:
 // export const collectionsState = atom({
 //   key: 'collectionsState',
@@ -61,6 +80,8 @@ export const allRecordIds = selector({
 export const connectToResources = (Component) => (props) => {
   const resources = useRecoilValue(resourcesState);
   const filters = useRecoilValue(filtersState);
+  // const vitalSigns = useRecoilValue(vitalSignsRecords);
+  // const labResults = useRecoilValue(labResultRecords);
   // useContext(DiscoveryContext);
 
   return (


### PR DESCRIPTION
* represent all records as a hash/Object/dictionary

* fix unnecessary re-renders occurring in Collections-view card list.

* eliminated array of records (`normalized`) from recoil state. 
  (will be replaced with some representation of uuids as an Array or Set, in combination with ^these changes.) 