### PR TITLE
fix timeline scaling

### DIFF
--- a/src/components/ContentPanel/ContentPanel.css
+++ b/src/components/ContentPanel/ContentPanel.css
@@ -331,7 +331,7 @@
   font-size: 1rem;
   background-color: var(--background-content);
   white-space: pre-wrap;
-  padding-right: 30px,
+  padding-right: 30px;
 }
 
 .content-panel-inner-body-alt {
@@ -348,7 +348,6 @@
   margin: 5px 5px 0 0;
   overflow: hidden;
   white-space: pre-wrap;
-  
 }
 
 .content-panel-inner-body-alt-container {

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -20,7 +20,7 @@ import {
   normalizeResourcesAndInjectPartipantId, generateRecordsDictionary, generateLegacyResources, computeFilterState, extractProviders, extractCategories,
 } from './Api';
 import {
-  resourcesState, filtersState, activeCategoriesState, activeProvidersState,
+  resourcesState, updateTimeFiltersState, activeCategoriesState, activeProvidersState,
 } from '../../recoil';
 
 import DiscoveryContext from '../DiscoveryContext';
@@ -86,15 +86,6 @@ class DiscoveryApp extends React.PureComponent {
     this.setState({ lastEvent: event });
   }
 
-  // Record thumb positions as returned from StandardFilters
-  setDateRange = (minDate, maxDate) => {
-    this.props.setFilters({
-      ...this.props.filters,
-      thumbLeftDate: minDate,
-      thumbRightDate: maxDate,
-    });
-  }
-
   onDotClick = (dotClickDate) => {
     this.setState({ dotClickDate });
   }
@@ -137,17 +128,17 @@ class DiscoveryApp extends React.PureComponent {
     const isSummary = activeView === 'summary';
 
     const {
-      resources, activeCategories, activeProviders, filters,
+      resources, activeCategories, activeProviders, timeFilters,
     } = this.props;
 
-    const { dates, thumbLeftDate, thumbRightDate } = filters;
+    const { dates, thumbLeftDate, thumbRightDate } = timeFilters;
 
     const {
       totalResCount, providers, categories,
     } = resources;
 
     return (
-      <DiscoveryContext.Provider value={{ ...this.state, ...this.props.filters }}>
+      <DiscoveryContext.Provider value={{ ...this.state, ...this.props.timeFilters }}>
         <div className="discovery-app">
           <PageHeader
             patientMode={patientMode}
@@ -164,7 +155,6 @@ class DiscoveryApp extends React.PureComponent {
                   catsEnabled={activeCategories}
                   providers={providers}
                   provsEnabled={activeProviders}
-                  dateRangeFn={this.setDateRange}
                   lastEvent={this.state.lastEvent}
                   // TODO: convert to use route path segment:
                   // allowDotClick={!['compare', 'catalog'].includes(activeView)}
@@ -256,7 +246,7 @@ class DiscoveryApp extends React.PureComponent {
 // if using React.memo, there's a proptype warning for Route:
 const DiscoveryAppHOC = (props) => {
   const [resources, setResources] = useRecoilState(resourcesState);
-  const [filters, setFilters] = useRecoilState(filtersState);
+  const [timeFilters, updateTimeFilters] = useRecoilState(updateTimeFiltersState);
   const activeCategories = useRecoilValue(activeCategoriesState);
   const activeProviders = useRecoilValue(activeProvidersState);
 
@@ -297,8 +287,8 @@ const DiscoveryAppHOC = (props) => {
           legacy,
         });
 
-        setFilters({
-          ...filters,
+        // TODO: migrate this call to recoil.js so it is automatically derived from resources.legacy, using DefaultValue api ?
+        updateTimeFilters({
           ...computeFilterState(legacy),
         });
       }).catch((error) => {
@@ -318,8 +308,8 @@ const DiscoveryAppHOC = (props) => {
       resources={resources}
       activeCategories={activeCategories}
       activeProviders={activeProviders}
-      filters={filters}
-      setFilters={setFilters}
+      timeFilters={timeFilters}
+      updateTimeFilters={updateTimeFilters}
     />
   );
 };

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -20,7 +20,7 @@ import {
   normalizeResourcesAndInjectPartipantId, generateRecordsDictionary, generateLegacyResources, computeFilterState, extractProviders, extractCategories,
 } from './Api';
 import {
-  resourcesState, updateTimeFiltersState, activeCategoriesState, activeProvidersState,
+  resourcesState, timeFiltersState, activeCategoriesState, activeProvidersState,
 } from '../../recoil';
 
 import DiscoveryContext from '../DiscoveryContext';
@@ -232,7 +232,7 @@ class DiscoveryApp extends React.PureComponent {
 // if using React.memo, there's a proptype warning for Route:
 const DiscoveryAppHOC = (props) => {
   const [resources, setResources] = useRecoilState(resourcesState);
-  const [timeFilters, updateTimeFilters] = useRecoilState(updateTimeFiltersState);
+  const [timeFilters, updateTimeFilters] = useRecoilState(timeFiltersState);
   const activeCategories = useRecoilValue(activeCategoriesState);
   const activeProviders = useRecoilValue(activeProvidersState);
 

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -45,7 +45,7 @@ class DiscoveryApp extends React.PureComponent {
     searchRefs: [], // Search results to highlight
     // isLoading: false,
     // fetchError: null, // Possible axios error object
-    lastEvent: null,
+    // lastEvent: null,
     // thumbLeftDate: null,
     // thumbRightDate: null,
     dotClickDate: null, // dot click from ContentPanel
@@ -70,20 +70,6 @@ class DiscoveryApp extends React.PureComponent {
     onlyMultisource: false, // TilesView & CompareView
 
     onlyAnnotated: false, // ContentPanel
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize', this.onEvent);
-    window.addEventListener('keydown', this.onEvent);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.onEvent);
-    window.removeEventListener('keydown', this.onEvent);
-  }
-
-  onEvent = (event) => {
-    this.setState({ lastEvent: event });
   }
 
   onDotClick = (dotClickDate) => {
@@ -155,7 +141,7 @@ class DiscoveryApp extends React.PureComponent {
                   catsEnabled={activeCategories}
                   providers={providers}
                   provsEnabled={activeProviders}
-                  lastEvent={this.state.lastEvent}
+                  // lastEvent={this.state.lastEvent}
                   // TODO: convert to use route path segment:
                   // allowDotClick={!['compare', 'catalog'].includes(activeView)}
                   allowDotClick

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -158,7 +158,6 @@ class DiscoveryApp extends React.PureComponent {
             <div className="inner-container">
               <div className="standard-filters" style={{ display: isSummary ? 'none' : 'block' }}>
                 <StandardFilters
-                  activeView={activeView}
                   resources={legacyResources}
                   dates={dates}
                   categories={categories}
@@ -180,7 +179,6 @@ class DiscoveryApp extends React.PureComponent {
                     <Switch>
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/summary`}>
                         <SummaryView
-                          activeView={activeView}
                           resources={legacyResources}
                           dates={dates}
                           categories={categories}
@@ -189,7 +187,6 @@ class DiscoveryApp extends React.PureComponent {
                       </Route>
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/catalog`}>
                         <TilesView
-                          activeView={activeView}
                           resources={this.props.resources}
                           totalResCount={totalResCount}
                           dates={dates}
@@ -203,7 +200,6 @@ class DiscoveryApp extends React.PureComponent {
                       </Route>
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/compare`}>
                         <CompareView
-                          activeView={activeView}
                           resources={this.props.resources}
                           totalResCount={totalResCount}
                           dates={dates}
@@ -218,7 +214,6 @@ class DiscoveryApp extends React.PureComponent {
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/timeline`}>
                         <ContentPanel
                           open
-                          activeView={activeView}
                           catsEnabled={activeCategories}
                           provsEnabled={activeProviders}
                           dotClickFn={this.onDotClick}

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -50,7 +50,7 @@ class StandardFilters extends React.PureComponent {
     activeProviders: PropTypes.shape({}).isRequired,
     // enabledFn: PropTypes.func.isRequired, // Callback to report changed category & provider enable/disable
     // dateRangeFn: PropTypes.func, // Optional callback to report changed thumb positions
-    lastEvent: PropTypes.instanceOf(Event),
+    // lastEvent: PropTypes.instanceOf(Event),
     allowDotClick: PropTypes.bool,
     dotClickDate: PropTypes.string,
   }
@@ -69,6 +69,8 @@ class StandardFilters extends React.PureComponent {
   }
 
   componentDidMount() {
+    window.addEventListener('resize', this.onResize);
+    // window.addEventListener('keydown', this.onEvent);
     this.updateSvgWidth();
     if (this.props.dates && this.props.allowDotClick) {
       this.props.setDotClickContext({
@@ -90,6 +92,15 @@ class StandardFilters extends React.PureComponent {
     // this.props.enabledFn(this.props.catsEnabled, this.props.provsEnabled);
   }
 
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.onResize);
+    // window.removeEventListener('keydown', this.onEvent);
+  }
+
+  onResize = (_event) => {
+    this.updateSvgWidth();
+  }
+
   componentDidUpdate(prevProps, prevState) {
     if (prevState.minActivePos !== this.state.minActivePos
       || prevState.maxActivePos !== this.state.maxActivePos
@@ -99,13 +110,6 @@ class StandardFilters extends React.PureComponent {
     }
 
     if (prevProps.lastEvent !== this.props.lastEvent) {
-      switch (this.props.lastEvent.type) {
-        case 'resize':
-        default:
-          this.updateSvgWidth();
-          break;
-      }
-
       // TODO: not sure why this was here, but if enabled, next/prev and dot-click don't work w/ searchRefs
       //      } else if (this.context.searchRefs && this.context.searchRefs.length > 0) {
       //   // If most recent searchRef differs from currently highlighted dot, set dotClickContext

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   atom,
   useRecoilState,
+  useSetRecoilState,
   useRecoilValue,
 } from 'recoil';
 import PropTypes from 'prop-types';
@@ -22,7 +23,7 @@ import Provider from '../Provider';
 import Unimplemented from '../Unimplemented';
 import DiscoveryContext from '../DiscoveryContext';
 
-import { activeCategoriesState, activeProvidersState } from '../../recoil';
+import { activeCategoriesState, activeProvidersState, updateTimeFiltersState } from '../../recoil';
 //
 // Render the "container" (with filters) for views of the participant's data
 //
@@ -48,7 +49,7 @@ class StandardFilters extends React.PureComponent {
     // provsEnabled: PropTypes.object.isRequired,
     activeProviders: PropTypes.shape({}).isRequired,
     // enabledFn: PropTypes.func.isRequired, // Callback to report changed category & provider enable/disable
-    dateRangeFn: PropTypes.func, // Optional callback to report changed thumb positions
+    // dateRangeFn: PropTypes.func, // Optional callback to report changed thumb positions
     lastEvent: PropTypes.instanceOf(Event),
     allowDotClick: PropTypes.bool,
     dotClickDate: PropTypes.string,
@@ -204,6 +205,14 @@ class StandardFilters extends React.PureComponent {
     return (target - min) / (max - min);
   }
 
+  // Record thumb positions as returned from StandardFilters
+  setDateRange = (minDate, maxDate) => {
+    this.props.updateTimeFilters({
+      thumbLeftDate: minDate,
+      thumbRightDate: maxDate,
+    });
+  }
+
   //
   // Handle TimeWidget left/right thumb movement
   //   minActivePos:  location [0..1] of left thumb
@@ -212,11 +221,9 @@ class StandardFilters extends React.PureComponent {
   //
   setLeftRight = (minActivePos, maxActivePos, isExpanded) => {
     //      console.log('minPos: ' + minActivePos + '  maxPos: ' + maxActivePos);
-    if (this.props.dateRangeFn) {
-      const minDate = this.posToDate(minActivePos);
-      const maxDate = this.posToDate(maxActivePos);
-      this.props.dateRangeFn(minDate, maxDate);
-    }
+    const minDate = this.posToDate(minActivePos);
+    const maxDate = this.posToDate(maxActivePos);
+    this.setDateRange(minDate, maxDate);
     this.setState({
       minActivePos,
       maxActivePos,
@@ -626,6 +633,7 @@ export const dotClickContextState = atom({
 });
 
 const StandardFiltersHOC = React.memo((props) => {
+  const updateTimeFilters = useSetRecoilState(updateTimeFiltersState);
   const [dotClickContext, setDotClickContext] = useRecoilState(dotClickContextState);
 
   const activeCategories = useRecoilValue(activeCategoriesState);
@@ -634,6 +642,7 @@ const StandardFiltersHOC = React.memo((props) => {
   return (
     <StandardFilters
       {...props} // eslint-disable-line react/jsx-props-no-spreading
+      updateTimeFilters={updateTimeFilters}
       dotClickContext={dotClickContext}
       setDotClickContext={setDotClickContext}
       activeCategories={activeCategories}

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -156,7 +156,8 @@ class StandardFilters extends React.PureComponent {
     const availableWidthEl = checkQuerySelector('#measure-available-width');
     if (availableWidthEl) {
       const availableWidth = availableWidthEl.getBoundingClientRect().width;
-      this.setState({ svgWidth: `${availableWidth}px` });
+      const MIN_WIDTH = 810;
+      this.setState({ svgWidth: `${Math.max(MIN_WIDTH, availableWidth)}px` });
     }
   }
 

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -23,7 +23,7 @@ import Provider from '../Provider';
 import Unimplemented from '../Unimplemented';
 import DiscoveryContext from '../DiscoveryContext';
 
-import { activeCategoriesState, activeProvidersState, updateTimeFiltersState } from '../../recoil';
+import { activeCategoriesState, activeProvidersState, timeFiltersState } from '../../recoil';
 //
 // Render the "container" (with filters) for views of the participant's data
 //
@@ -638,7 +638,7 @@ export const dotClickContextState = atom({
 });
 
 const StandardFiltersHOC = React.memo((props) => {
-  const updateTimeFilters = useSetRecoilState(updateTimeFiltersState);
+  const updateTimeFilters = useSetRecoilState(timeFiltersState);
   const [dotClickContext, setDotClickContext] = useRecoilState(dotClickContextState);
 
   const activeCategories = useRecoilValue(activeCategoriesState);

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -22,7 +22,6 @@ import Provider from '../Provider';
 import Unimplemented from '../Unimplemented';
 import DiscoveryContext from '../DiscoveryContext';
 
-import { SUBROUTES } from '../../constants';
 import { activeCategoriesState, activeProvidersState } from '../../recoil';
 //
 // Render the "container" (with filters) for views of the participant's data
@@ -31,7 +30,6 @@ class StandardFilters extends React.PureComponent {
   static contextType = DiscoveryContext; // Allow the shared context to be accessed via 'this.context'
 
   static propTypes = {
-    activeView: PropTypes.oneOf(SUBROUTES),
     resources: PropTypes.instanceOf(FhirTransform),
     dates: PropTypes.shape({
       allDates: PropTypes.arrayOf(PropTypes.shape({

--- a/src/components/TimeWidget/TimeWidget.css
+++ b/src/components/TimeWidget/TimeWidget.css
@@ -96,7 +96,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  /* originally: min-width: 810px; */
+  min-width: 810px;
   height: 100px;
   max-height: 100px;
   background-color: transparent;

--- a/src/components/TimeWidget/TimeWidget.css
+++ b/src/components/TimeWidget/TimeWidget.css
@@ -95,7 +95,6 @@
 .timeline-controls {
   display: flex;
   flex-direction: column;
-  width: 100%;
   min-width: 810px;
   height: 100px;
   max-height: 100px;
@@ -236,7 +235,7 @@
   left: 0;
   display: flex;
   justify-content: center;
-  width: 100%;
+  /* width: 100%; */
   height: 40px;
   min-height: 40px;
   max-height: 40px;
@@ -469,7 +468,7 @@
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: initial;
-  width: auto;
+  /* width: auto; */
   height: 38px;
   max-height: 38px;
   background-color: var(--background-timeline);

--- a/src/components/TimeWidget/index.js
+++ b/src/components/TimeWidget/index.js
@@ -13,7 +13,6 @@ import SVGContainer from '../SVGContainer';
 import DotLine from '../DotLine';
 
 import DiscoveryContext from '../DiscoveryContext';
-import CategoryRollup from '../CategoryRollup';
 
 //
 // Render the DiscoveryApp Time Widget
@@ -427,7 +426,7 @@ export default class TimeWidget extends React.Component {
             >
               <DotLine
                 dotPositions={this.props.dotPositionsFn('CategoryRollup', 'Categories', true)}
-                context={{ parent: CategoryRollup.myName, rowName: 'Categories' }}
+                context={{ parent: 'Category', rowName: 'Categories' }}
                 dotClickFn={this.props.dotClickFn}
               />
             </SVGContainer>

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -20,8 +20,8 @@ export const resourcesState = atom({
   // dangerouslyAllowMutability: true, // < Object.isExtensible(res.data), in: src/components/Annotation/index.js
 });
 
-const timeFiltersState = atom({
-  key: 'timeFiltersState',
+const timeFilters = atom({
+  key: 'timeFilters',
   default: {
     dates: null,
     thumbLeftDate: null,
@@ -31,10 +31,10 @@ const timeFiltersState = atom({
 
 export const updateTimeFiltersState = selector({
   key: 'updateTimeFiltersState',
-  get: ({ get }) => get(timeFiltersState),
+  get: ({ get }) => get(timeFilters),
   set: ({ get, set }, newValues) => {
-    const previousValues = get(timeFiltersState);
-    set(timeFiltersState, {
+    const previousValues = get(timeFilters);
+    set(timeFilters, {
       ...previousValues,
       ...newValues,
     });

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -29,8 +29,8 @@ const timeFilters = atom({
   },
 });
 
-export const updateTimeFiltersState = selector({
-  key: 'updateTimeFiltersState',
+export const timeFiltersState = selector({
+  key: 'timeFiltersState',
   get: ({ get }) => get(timeFilters),
   set: ({ get, set }, newValues) => {
     const previousValues = get(timeFilters);

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -20,12 +20,24 @@ export const resourcesState = atom({
   // dangerouslyAllowMutability: true, // < Object.isExtensible(res.data), in: src/components/Annotation/index.js
 });
 
-export const filtersState = atom({
-  key: 'filtersState',
+const timeFiltersState = atom({
+  key: 'timeFiltersState',
   default: {
     dates: null,
     thumbLeftDate: null,
     thumbRightDate: null,
+  },
+});
+
+export const updateTimeFiltersState = selector({
+  key: 'updateTimeFiltersState',
+  get: ({ get }) => get(timeFiltersState),
+  set: ({ get, set }, newValues) => {
+    const previousValues = get(timeFiltersState);
+    set(timeFiltersState, {
+      ...previousValues,
+      ...newValues,
+    });
   },
 });
 


### PR DESCRIPTION
also:

* remove unused activeView props

* simpler `updateTimeFiltersState` implementation that accesses previous state and sets new values

* move window resize handler into "StandardFilters" component

* remove the keydown event handler at top level, which causes unnecessary re-renders (and appears unused?) 