### PR TITLE
Fix Collections view not to error whenever medications are involved

### DIFF
--- a/src/components/cards/MedicationCardBody.js
+++ b/src/components/cards/MedicationCardBody.js
@@ -19,7 +19,7 @@ const MedicationCardBody = ({ fieldsData }) => {
 
   function formatDosageStart() {
     if (fieldsData.dosageInstruction?.timing?.repeat?.boundsPeriod) {
-      return formatDate(fieldsData.dosageInstruction.timing.repeat.boundsPeriod);
+      return formatDate(fieldsData.dosageInstruction.timing.repeat.boundsPeriod.start);
     }
 
     return null;

--- a/src/components/cards/MedicationCardBody.js
+++ b/src/components/cards/MedicationCardBody.js
@@ -18,7 +18,7 @@ const MedicationCardBody = ({ fieldsData }) => {
   }
 
   function formatDosageStart() {
-    if (fieldsData.dosageInstruction?.timing?.repeat?.boundsPeriod) {
+    if (fieldsData.dosageInstruction?.timing?.repeat?.boundsPeriod?.start) {
       return formatDate(fieldsData.dosageInstruction.timing.repeat.boundsPeriod.start);
     }
 
@@ -81,7 +81,7 @@ const MedicationCardBody = ({ fieldsData }) => {
         value={formatDosageInstruction()}
       />
       <CardBodyField
-        dependency={fieldsData.dosageInstruction?.timing?.repeat?.boundsPeriod}
+        dependency={fieldsData.dosageInstruction?.timing?.repeat?.boundsPeriod?.start}
         label="STARTING ON"
         value={formatDosageStart()}
       />


### PR DESCRIPTION
This card is talking about when the Medications are starting, so it should use the `Period.start` date if it's available.

Fixed view:

![image](https://user-images.githubusercontent.com/110988/106618905-4dbe6d00-6570-11eb-8895-70b4127ca946.png)
