### PR TITLE
Display dates from DSTU2 resources in Medications view correctly

### DIFF
--- a/src/components/cards/MedicationCardBody.js
+++ b/src/components/cards/MedicationCardBody.js
@@ -13,7 +13,7 @@ const MedicationCardBody = ({ fieldsData }) => {
       const { period } = fieldsData.dosageInstruction.timing.repeat;
       // DSTU2 / STU3 compatibility
       const { periodUnit, periodUnits } = fieldsData.dosageInstruction.timing.repeat;
-      return `${frequency} every ${period} ${periodUnit ?? periodUnits} ${asNeededText}`; // need dynamic translation for
+      return `${frequency} every ${period} ${periodUnit || periodUnits} ${asNeededText}`; // need dynamic translation for
     }
     return null;
   }

--- a/src/components/cards/MedicationCardBody.js
+++ b/src/components/cards/MedicationCardBody.js
@@ -11,8 +11,9 @@ const MedicationCardBody = ({ fieldsData }) => {
         : 'as instructed'; // what the opposite of As Needed?
       const { frequency } = fieldsData.dosageInstruction.timing.repeat;
       const { period } = fieldsData.dosageInstruction.timing.repeat;
-      const { periodUnit } = fieldsData.dosageInstruction.timing.repeat;
-      return `${frequency} every ${period} ${periodUnit} ${asNeededText}`; // need dynamic translation for
+      // DSTU2 / STU3 compatibility
+      const { periodUnit, periodUnits } = fieldsData.dosageInstruction.timing.repeat;
+      return `${frequency} every ${period} ${periodUnit ?? periodUnits} ${asNeededText}`; // need dynamic translation for
     }
     return null;
   }


### PR DESCRIPTION
The element `periodUnits` was renamed to `periodUnit` in STU3. Fixes this:

![image](https://user-images.githubusercontent.com/110988/106623221-abed4f00-6574-11eb-9573-cf2a1b3bb415.png)
