### PR TITLE
Layout widths scoped to route

### DIFF
--- a/src/components/Collections/index.js
+++ b/src/components/Collections/index.js
@@ -2,19 +2,6 @@ import React from 'react';
 
 import { useRecoilValue } from 'recoil';
 import { allRecordIds, resourcesState, patientRecord } from '../../recoil';
-import PersistentDrawerRight from '../ContentPanel/Drawer';
-import RecordCard from '../cards/RecordCard';
-
-const CardList = ({
-  recordIds, records, patient,
-}) => recordIds.map((uuid) => (
-  <RecordCard
-    key={`record-card-${uuid}`}
-    recordId={uuid}
-    records={records}
-    patient={patient}
-  />
-));
 
 const Collections = () => {
   const recordIds = useRecoilValue(allRecordIds);
@@ -41,16 +28,11 @@ const Collections = () => {
         <pre>
           { JSON.stringify(records, null, '  ') }
         </pre>
+        <h4>recordIds:</h4>
+        <pre>
+          { JSON.stringify(recordIds, null, '  ') }
+        </pre>
       </div>
-      <PersistentDrawerRight>
-        <div className="card-list">
-          <CardList
-            recordIds={recordIds}
-            records={records}
-            patient={patient}
-          />
-        </div>
-      </PersistentDrawerRight>
     </div>
   );
 };

--- a/src/components/DiscoveryApp/DiscoveryApp.css
+++ b/src/components/DiscoveryApp/DiscoveryApp.css
@@ -36,7 +36,7 @@ button:focus {
   overflow-y: hidden;
 }
 
-.outer-container {
+#outer-container {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -48,7 +48,7 @@ button:focus {
     padding-top: var(--top-header-height);
   }
 
-  > .inner-container {
+  > #inner-container {
     margin-top: 56px;
     width: calc(100vw - var(--left-nav-width) - var(--right-details-width));
 
@@ -86,7 +86,7 @@ button:focus {
 
     & div.card-list { /* MUI views */
       /* appears this width causes to card container to grow beyond the window */
-      /* width: var(--right-details-width); */ 
+      /* width: var(--right-details-width); */
       height: calc(100vh - var(--top-header-height) - 70px);
       overflow: scroll;
     }

--- a/src/components/DiscoveryApp/DiscoveryApp.css
+++ b/src/components/DiscoveryApp/DiscoveryApp.css
@@ -43,7 +43,7 @@ button:focus {
   width: 100vw;
   height: 100vh;
 
-  > #left-nav {
+  > #left-filters {
     width: var(--left-nav-width);
     padding-top: var(--top-header-height);
   }

--- a/src/components/DiscoveryApp/DiscoveryApp.css
+++ b/src/components/DiscoveryApp/DiscoveryApp.css
@@ -50,7 +50,6 @@ button:focus {
 
   > #inner-container {
     margin-top: 56px;
-    width: calc(100vw - var(--left-nav-width) - var(--right-details-width));
 
     > .standard-filters {
       width: 100%;
@@ -64,11 +63,7 @@ button:focus {
       }
 
       > main {
-        & .collections-content {
-          width: calc(100vw - var(--left-nav-width) - var(--right-details-width) - 16px);
-          height: calc(100vh - 260px);
-          overflow: scroll;
-        }
+        /* placeholder */
       }
     }
   }
@@ -89,6 +84,36 @@ button:focus {
       /* width: var(--right-details-width); */
       height: calc(100vh - var(--top-header-height) - 70px);
       overflow: scroll;
+    }
+  }
+
+  &.route-summary {
+    > #inner-container {
+      width: 100vw;
+    }
+  }
+
+  &.route-catalog,
+  &.route-compare {
+    > #inner-container {
+      width: calc(100vw - var(--left-nav-width) - var(--right-details-width));
+    }
+  }
+
+  &.route-collections {
+    > #inner-container {
+      width: calc(100vw - var(--left-nav-width));
+
+      > #below-timeline {
+        > main {
+          & .collections-content {
+            /* TODO: eliminate height/width, here, and implement actual scrolling in individual panels? */
+            width: calc(100vw - var(--left-nav-width) - 16px);
+            height: calc(100vh - 260px);
+            overflow: scroll;
+          }
+        }
+      }
     }
   }
 }

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -130,9 +130,9 @@ class DiscoveryApp extends React.PureComponent {
             patientMode={patientMode}
             participantId={participantId}
           />
-          <div className="outer-container">
+          <div id="outer-container">
             <div id="left-nav" style={{ display: isSummary ? 'none' : 'block' }} />
-            <div className="inner-container">
+            <div id="inner-container">
               <div className="standard-filters" style={{ display: isSummary ? 'none' : 'block' }}>
                 <StandardFilters
                   resources={legacyResources}

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -131,7 +131,7 @@ class DiscoveryApp extends React.PureComponent {
             participantId={participantId}
           />
           <div id="outer-container">
-            <div id="left-nav" style={{ display: isSummary ? 'none' : 'block' }} />
+            <div id="left-filters" style={{ display: isSummary ? 'none' : 'block' }} />
             <div id="inner-container">
               <div className="standard-filters" style={{ display: isSummary ? 'none' : 'block' }}>
                 <StandardFilters

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -136,6 +136,7 @@ class DiscoveryApp extends React.PureComponent {
             <div id="inner-container">
               <div className="standard-filters" style={{ display: isSummary ? 'none' : 'block' }}>
                 <StandardFilters
+                  activeView={activeView} // trigger timeline resizing when route changes
                   resources={legacyResources}
                   dates={dates}
                   categories={categories}

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -130,7 +130,7 @@ class DiscoveryApp extends React.PureComponent {
             patientMode={patientMode}
             participantId={participantId}
           />
-          <div id="outer-container">
+          <div id="outer-container" className={`route-${activeView}`}>
             <div id="left-filters" style={{ display: isSummary ? 'none' : 'block' }} />
             <div id="inner-container">
               <div className="standard-filters" style={{ display: isSummary ? 'none' : 'block' }}>

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -112,6 +112,7 @@ class DiscoveryApp extends React.PureComponent {
     const { match: { params: { activeView = 'summary', patientMode, participantId } } } = this.props;
 
     const isSummary = activeView === 'summary';
+    const hasCardListRight = ['catalog', 'compare'].includes(activeView);
 
     const {
       resources, activeCategories, activeProviders, timeFilters,
@@ -220,7 +221,7 @@ class DiscoveryApp extends React.PureComponent {
                 </main>
               </div>
             </div>
-            { !isSummary && <div id="details-right" /> }
+            { hasCardListRight && <div id="details-right" /> }
           </div>
           <PageFooter resources={legacyResources} />
         </div>

--- a/src/components/SelectedCardCollection.js
+++ b/src/components/SelectedCardCollection.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { useRecoilValue } from 'recoil';
+import {
+  resourcesState, patientRecord, allRecordIds, // groupedRecordIdsState,
+} from '../recoil';
+import PersistentDrawerRight from './ContentPanel/Drawer';
+import RecordCard from './cards/RecordCard';
+
+const SelectedCardCollection = () => {
+  const resources = useRecoilValue(resourcesState);
+  // const groupedRecordIds = useRecoilValue(groupedRecordIdsState);
+  const recordIds = useRecoilValue(allRecordIds);
+  const patient = useRecoilValue(patientRecord);
+
+  const {
+    records, // categories, providers,
+  } = resources;
+
+  return (
+    <PersistentDrawerRight>
+      <div className="card-list">
+        {recordIds.map((uuid) => (
+          <RecordCard
+            key={`record-card-${uuid}`}
+            recordId={uuid}
+            records={records}
+            patient={patient}
+          />
+        ))}
+      </div>
+    </PersistentDrawerRight>
+  );
+};
+
+export default React.memo(SelectedCardCollection);

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -599,7 +599,7 @@ class StandardFilters extends React.PureComponent {
   )
 
   portalLeftNav = () => {
-    const leftNavTarget = document.getElementById('left-nav');
+    const leftNavTarget = document.getElementById('left-filters');
     if (leftNavTarget) {
       return ReactDOM.createPortal((this.renderLeftNav()), leftNavTarget);
     }

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -23,6 +23,7 @@ import Provider from '../Provider';
 import Unimplemented from '../Unimplemented';
 import DiscoveryContext from '../DiscoveryContext';
 
+import { SUBROUTES } from '../../constants';
 import { activeCategoriesState, activeProvidersState, timeFiltersState } from '../../recoil';
 //
 // Render the "container" (with filters) for views of the participant's data
@@ -31,6 +32,7 @@ class StandardFilters extends React.PureComponent {
   static contextType = DiscoveryContext; // Allow the shared context to be accessed via 'this.context'
 
   static propTypes = {
+    activeView: PropTypes.oneOf(SUBROUTES),
     resources: PropTypes.instanceOf(FhirTransform),
     dates: PropTypes.shape({
       allDates: PropTypes.arrayOf(PropTypes.shape({
@@ -102,6 +104,10 @@ class StandardFilters extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    if (prevProps.activeView !== this.props.activeView) {
+      this.updateSvgWidth();
+    }
+
     if (prevState.minActivePos !== this.state.minActivePos
       || prevState.maxActivePos !== this.state.maxActivePos
       || notEqJSON(prevProps.activeCategories, this.props.activeCategories)

--- a/src/components/TilesView/index.js
+++ b/src/components/TilesView/index.js
@@ -11,7 +11,7 @@ import FhirTransform from '../../FhirTransform.js';
 import { primaryTextValue } from '../../fhirUtil.js';
 
 import Unimplemented from '../Unimplemented';
-import ContentPanel from '../ContentPanel/ContentRight';
+import SelectedCardCollection from '../SelectedCardCollection';
 
 import DiscoveryContext from '../DiscoveryContext';
 
@@ -708,27 +708,7 @@ export default class TilesView extends React.PureComponent {
           </div>
           ) }
         </div>
-        <ContentPanel
-          open
-          catsEnabled={this.props.catsEnabled}
-          provsEnabled={this.props.provsEnabled}
-          containerClassName="content-panel-tiles-view"
-          topBoundFn={() => this.state.topBound}
-          bottomBoundFn={this.contentPanelBottomBound}
-          initialPositionYFn={this.initialPositionY.bind(this)}
-          onResizeFn={this.onContentPanelResize.bind(this)}
-          nextPrevFn={this.props.nextPrevFn}
-          thumbLeftDate={this.props.thumbLeftDate}
-          thumbRightDate={this.props.thumbRightDate}
-          resources={this.selectedTileResources()}
-          patient={this.props.resources.patient}
-          providers={this.props.resources.providers}
-          totalResCount={this.props.totalResCount}
-          viewName="Tiles"
-          viewIconClass="tiles-view-icon"
-          tileSort
-          noResultDisplay={Object.keys(this.state.uniqueStruct).length > 0 ? 'No Card is selected' : 'No data to display'}
-        />
+        <SelectedCardCollection />
       </div>
     );
   }


### PR DESCRIPTION

* Summary view occupies full window width:
![image](https://user-images.githubusercontent.com/3383704/106654931-bacd0500-6566-11eb-9a53-8dbaaa9d15cf.png)



* Collections view (and its timeline) occupy the full window width:  (and eliminate MUI card list)
![image](https://user-images.githubusercontent.com/3383704/106656448-b6a1e700-6568-11eb-8714-b2d20006ef8f.png)

* MUI cardlist replaces legacy card list on Catalog view.
