### PR TITLE
Convert handmade category/provider selectors to MUI Checkboxes

### DIFF
--- a/src/components/Category/index.js
+++ b/src/components/Category/index.js
@@ -14,6 +14,9 @@ const useStyles = makeStyles(() => ({
   label: {
     fontSize: ".8em",
   },
+  checkbox: {
+    padding: 1,
+  },
 }));
 
 const Category = ({ categoryName }) => {
@@ -36,7 +39,12 @@ const Category = ({ categoryName }) => {
     <FormControlLabel
       classes={classes}
       control={
-        <Checkbox checked={isEnabled} onChange={handleChange} color="primary" />
+        <Checkbox
+          className={classes.checkbox}
+          checked={isEnabled}
+          onChange={handleChange}
+          color="primary"
+        />
       }
       label={categoryName}
     />

--- a/src/components/Category/index.js
+++ b/src/components/Category/index.js
@@ -51,7 +51,7 @@ const Category = ({ categoryName }) => {
   );
 };
 
-Category.myName = "Category";
+Category.myName = 'Category';
 
 Category.propTypes = {
   categoryName: PropTypes.string.isRequired,

--- a/src/components/Category/index.js
+++ b/src/components/Category/index.js
@@ -1,22 +1,27 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { useRecoilState } from 'recoil';
-import { makeStyles } from '@material-ui/core/styles';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
+import React from "react";
+import PropTypes from "prop-types";
+import { useRecoilState } from "recoil";
+import { makeStyles } from "@material-ui/core/styles";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
 
-import { activeCategoriesState } from '../../recoil';
+import { activeCategoriesState } from "../../recoil";
 
 const useStyles = makeStyles(() => ({
   root: {
     marginLeft: 5,
-  }
+  },
+  label: {
+    fontSize: ".8em",
+  },
 }));
 
 const Category = ({ categoryName }) => {
   const classes = useStyles();
 
-  const [activeCategories, setActiveCategories] = useRecoilState(activeCategoriesState);
+  const [activeCategories, setActiveCategories] = useRecoilState(
+    activeCategoriesState
+  );
 
   const isEnabled = activeCategories[categoryName];
 
@@ -28,21 +33,17 @@ const Category = ({ categoryName }) => {
   };
 
   return (
-    <FormControlLabel className={classes.root}
-
+    <FormControlLabel
+      classes={classes}
       control={
-        <Checkbox
-          checked={isEnabled}
-          onChange={handleChange}
-          color="primary"
-        />
+        <Checkbox checked={isEnabled} onChange={handleChange} color="primary" />
       }
       label={categoryName}
     />
   );
 };
 
-Category.myName = 'Category';
+Category.myName = "Category";
 
 Category.propTypes = {
   categoryName: PropTypes.string.isRequired,

--- a/src/components/Category/index.js
+++ b/src/components/Category/index.js
@@ -1,11 +1,11 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { useRecoilState } from "recoil";
-import { makeStyles } from "@material-ui/core/styles";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Checkbox from "@material-ui/core/Checkbox";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useRecoilState } from 'recoil';
+import { makeStyles } from '@material-ui/core/styles';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
 
-import { activeCategoriesState } from "../../recoil";
+import { activeCategoriesState } from '../../recoil';
 
 const useStyles = makeStyles(() => ({
   root: {

--- a/src/components/Category/index.js
+++ b/src/components/Category/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useRecoilState } from 'recoil';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
 
 import '../../css/Selector.css';
 import { activeCategoriesState } from '../../recoil';
@@ -13,7 +15,7 @@ const Category = ({ categoryName }) => {
 
   const isEnabled = activeCategories[categoryName];
 
-  const handleButtonClick = () => {
+  const handleChange = () => {
     setActiveCategories((prevActiveCategories) => ({
       ...prevActiveCategories,
       [categoryName]: !isEnabled,
@@ -21,11 +23,20 @@ const Category = ({ categoryName }) => {
   };
 
   return (
-    <div className="selector">
-      <div className="selector-nav">
-        <button className={isEnabled ? 'selector-button-enabled' : 'selector-button-disabled'} onClick={handleButtonClick}>
-          { categoryName }
-        </button>
+    <div>
+      <div>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={isEnabled}
+              onChange={handleChange}
+              color="primary"
+            />
+          }
+          label={categoryName}
+          classes="label"
+          className="provider-selector-nav"
+        />
       </div>
     </div>
   );

--- a/src/components/Category/index.js
+++ b/src/components/Category/index.js
@@ -1,16 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useRecoilState } from 'recoil';
+import { makeStyles } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 
-import '../../css/Selector.css';
 import { activeCategoriesState } from '../../recoil';
 
-//
-// Render a DiscoveryApp category line
-//
+const useStyles = makeStyles(() => ({
+  root: {
+    marginLeft: 5,
+  }
+}));
+
 const Category = ({ categoryName }) => {
+  const classes = useStyles();
+
   const [activeCategories, setActiveCategories] = useRecoilState(activeCategoriesState);
 
   const isEnabled = activeCategories[categoryName];
@@ -23,22 +28,17 @@ const Category = ({ categoryName }) => {
   };
 
   return (
-    <div>
-      <div>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={isEnabled}
-              onChange={handleChange}
-              color="primary"
-            />
-          }
-          label={categoryName}
-          classes="label"
-          className="provider-selector-nav"
+    <FormControlLabel className={classes.root}
+
+      control={
+        <Checkbox
+          checked={isEnabled}
+          onChange={handleChange}
+          color="primary"
         />
-      </div>
-    </div>
+      }
+      label={categoryName}
+    />
   );
 };
 

--- a/src/components/Provider/index.js
+++ b/src/components/Provider/index.js
@@ -41,7 +41,6 @@ const Provider = ({ providerName }) => {
             <Checkbox
               checked={isEnabled}
               onChange={handleChange}
-              name="titleCase(providerName)"
               color="primary"
             />
           }

--- a/src/components/Provider/index.js
+++ b/src/components/Provider/index.js
@@ -1,12 +1,12 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { useRecoilState } from "recoil";
-import { makeStyles } from "@material-ui/core/styles";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Checkbox from "@material-ui/core/Checkbox";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useRecoilState } from 'recoil';
+import { makeStyles } from '@material-ui/core/styles';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
 
-import { titleCase } from "../../util.js";
-import { activeProvidersState } from "../../recoil";
+import { titleCase } from '../../util.js';
+import { activeProvidersState } from '../../recoil';
 
 const useStyles = makeStyles(() => ({
   root: {

--- a/src/components/Provider/index.js
+++ b/src/components/Provider/index.js
@@ -15,6 +15,9 @@ const useStyles = makeStyles(() => ({
   label: {
     fontSize: ".8em",
   },
+  checkbox: {
+    padding: 1,
+  },
 }));
 
 const Provider = ({ providerName }) => {
@@ -37,7 +40,12 @@ const Provider = ({ providerName }) => {
     <FormControlLabel
       classes={classes}
       control={
-        <Checkbox checked={isEnabled} onChange={handleChange} color="primary" />
+        <Checkbox
+          className={classes.checkbox}
+          checked={isEnabled}
+          onChange={handleChange}
+          color="primary"
+        />
       }
       label={titleCase(providerName)}
     />

--- a/src/components/Provider/index.js
+++ b/src/components/Provider/index.js
@@ -52,7 +52,7 @@ const Provider = ({ providerName }) => {
   );
 };
 
-Provider.myName = "Category";
+Provider.myName = 'Category';
 
 Provider.propTypes = {
   providerName: PropTypes.string.isRequired,

--- a/src/components/Provider/index.js
+++ b/src/components/Provider/index.js
@@ -1,23 +1,28 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { useRecoilState } from 'recoil';
+import React from "react";
+import PropTypes from "prop-types";
+import { useRecoilState } from "recoil";
 import { makeStyles } from "@material-ui/core/styles";
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
 
-import { titleCase } from '../../util.js';
-import { activeProvidersState } from '../../recoil';
+import { titleCase } from "../../util.js";
+import { activeProvidersState } from "../../recoil";
 
 const useStyles = makeStyles(() => ({
   root: {
     marginLeft: 5,
+  },
+  label: {
+    fontSize: ".8em",
   },
 }));
 
 const Provider = ({ providerName }) => {
   const classes = useStyles();
 
-  const [activeProviders, setActiveProviders] = useRecoilState(activeProvidersState);
+  const [activeProviders, setActiveProviders] = useRecoilState(
+    activeProvidersState
+  );
 
   const isEnabled = activeProviders[providerName];
 
@@ -29,23 +34,17 @@ const Provider = ({ providerName }) => {
   };
 
   return (
-    <FormControlLabel className={classes.root}
+    <FormControlLabel
+      classes={classes}
       control={
-        <Checkbox
-          checked={isEnabled}
-          onChange={handleChange}
-          color="primary"
-        />
+        <Checkbox checked={isEnabled} onChange={handleChange} color="primary" />
       }
       label={titleCase(providerName)}
-      sx={{
-        marginLeft: 20
-      }}
     />
   );
 };
 
-Provider.myName = 'Category';
+Provider.myName = "Category";
 
 Provider.propTypes = {
   providerName: PropTypes.string.isRequired,

--- a/src/components/Provider/index.js
+++ b/src/components/Provider/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useRecoilState } from 'recoil';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
 
 import '../../css/Selector.css';
 import { titleCase } from '../../util.js';
@@ -14,19 +16,39 @@ const Provider = ({ providerName }) => {
 
   const isEnabled = activeProviders[providerName];
 
-  const handleButtonClick = () => {
+  const handleChange = () => {
     setActiveProviders((prevActiveCategories) => ({
       ...prevActiveCategories,
       [providerName]: !isEnabled,
     }));
   };
 
+  // return (
+  //   <div className="selector">
+  //     <div className="selector-nav">
+  //       <button className={isEnabled ? 'selector-button-enabled' : 'selector-button-disabled'} onClick={handleButtonClick}>
+  //         { titleCase(providerName) }
+  //       </button>
+  //     </div>
+  //   </div>
+  // );
+
   return (
-    <div className="selector">
-      <div className="selector-nav">
-        <button className={isEnabled ? 'selector-button-enabled' : 'selector-button-disabled'} onClick={handleButtonClick}>
-          { titleCase(providerName) }
-        </button>
+    <div>
+      <div>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={isEnabled}
+              onChange={handleChange}
+              name="titleCase(providerName)"
+              color="primary"
+            />
+          }
+          label={titleCase(providerName)}
+          classes="label"
+          className="provider-selector-nav"
+        />
       </div>
     </div>
   );

--- a/src/components/Provider/index.js
+++ b/src/components/Provider/index.js
@@ -1,17 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useRecoilState } from 'recoil';
+import { makeStyles } from "@material-ui/core/styles";
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 
-import '../../css/Selector.css';
 import { titleCase } from '../../util.js';
 import { activeProvidersState } from '../../recoil';
 
-//
-// Render a DiscoveryApp provider line
-//
+const useStyles = makeStyles(() => ({
+  root: {
+    marginLeft: 5,
+  },
+}));
+
 const Provider = ({ providerName }) => {
+  const classes = useStyles();
+
   const [activeProviders, setActiveProviders] = useRecoilState(activeProvidersState);
 
   const isEnabled = activeProviders[providerName];
@@ -23,33 +28,20 @@ const Provider = ({ providerName }) => {
     }));
   };
 
-  // return (
-  //   <div className="selector">
-  //     <div className="selector-nav">
-  //       <button className={isEnabled ? 'selector-button-enabled' : 'selector-button-disabled'} onClick={handleButtonClick}>
-  //         { titleCase(providerName) }
-  //       </button>
-  //     </div>
-  //   </div>
-  // );
-
   return (
-    <div>
-      <div>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={isEnabled}
-              onChange={handleChange}
-              color="primary"
-            />
-          }
-          label={titleCase(providerName)}
-          classes="label"
-          className="provider-selector-nav"
+    <FormControlLabel className={classes.root}
+      control={
+        <Checkbox
+          checked={isEnabled}
+          onChange={handleChange}
+          color="primary"
         />
-      </div>
-    </div>
+      }
+      label={titleCase(providerName)}
+      sx={{
+        marginLeft: 20
+      }}
+    />
   );
 };
 

--- a/src/css/Selector.css
+++ b/src/css/Selector.css
@@ -115,6 +115,17 @@
   cursor: default;
 }
 
+.provider-selector-nav {
+  /* @insert .selector-button; */
+
+  text-overflow: ellipsis;
+  overflow: hidden;
+  width: 160px;
+  max-width: 160px;
+  height: auto;
+  font-size: 0.75rem;
+}
+
 /* Common for @insert */
 .selector-button {
   display: flex;

--- a/src/css/Selector.css
+++ b/src/css/Selector.css
@@ -115,17 +115,6 @@
   cursor: default;
 }
 
-.provider-selector-nav {
-  /* @insert .selector-button; */
-
-  text-overflow: ellipsis;
-  overflow: hidden;
-  width: 160px;
-  max-width: 160px;
-  height: auto;
-  font-size: 0.75rem;
-}
-
 /* Common for @insert */
 .selector-button {
   display: flex;


### PR DESCRIPTION
The previous selectors have now been converted to checkboxes:

![discovery-checkboxes-demo](https://user-images.githubusercontent.com/110988/106919986-ee489480-670a-11eb-9067-424b1b2c3513.gif)

