### PR TITLE
Timeline styles

### DIFF
--- a/src/components/DotLine/index.js
+++ b/src/components/DotLine/index.js
@@ -37,6 +37,8 @@ export default class DotLine extends React.Component {
     const style = this.props.dotClickFn ? {} : { cursor: 'default' };
     const isContent = ['Category', 'Provider'].includes(this.props.context.parent);
 
+    console.log('dotPositions:', this.props.dotPositions)
+    
     switch (dot.dotType) {
       case 'inactive':
       case 'inactive-highlight':
@@ -156,6 +158,8 @@ export default class DotLine extends React.Component {
 
     return result;
   }
+
+  
 
   render() {
     return this.props.dotPositions.length > 0 ? this.props.dotPositions.reduce(this.renderDot, []) : null;

--- a/src/components/DotLine/index.js
+++ b/src/components/DotLine/index.js
@@ -27,8 +27,6 @@ export default class DotLine extends React.Component {
     dotClickFn: PropTypes.func, // Callback when a dot is clicked
   }
 
-  
-
   //
   // Accumulate array of svg <circle> elements for dots
   //

--- a/src/components/DotLine/index.js
+++ b/src/components/DotLine/index.js
@@ -27,6 +27,8 @@ export default class DotLine extends React.Component {
     dotClickFn: PropTypes.func, // Callback when a dot is clicked
   }
 
+  
+
   //
   // Accumulate array of svg <circle> elements for dots
   //
@@ -37,8 +39,6 @@ export default class DotLine extends React.Component {
     const style = this.props.dotClickFn ? {} : { cursor: 'default' };
     const isContent = ['Category', 'Provider'].includes(this.props.context.parent);
 
-    console.log('dotPositions:', this.props.dotPositions)
-    
     switch (dot.dotType) {
       case 'inactive':
       case 'inactive-highlight':
@@ -158,8 +158,6 @@ export default class DotLine extends React.Component {
 
     return result;
   }
-
-  
 
   render() {
     return this.props.dotPositions.length > 0 ? this.props.dotPositions.reduce(this.renderDot, []) : null;

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -185,9 +185,7 @@ class StandardFilters extends React.PureComponent {
   // Is 'dot':  (1) in the TimeWidget's active range
   //    (2) associated with an active Category
   //    (3) associated with an active Provider
-  isActive = (dot) =>
-    // console.log('this.state.activeDates', this.state.activeDates)
-    (this.state.activeDates[dateOnly(dot.date)])
+  isActive = (dot) => this.state.activeDates[dateOnly(dot.date)]
 
   //
   // Mark a position-scaled copy of this dot with 'dotType' and include in result array
@@ -295,7 +293,6 @@ class StandardFilters extends React.PureComponent {
     const thumbDistance = this.state.maxActivePos - this.state.minActivePos;
     const oldPosition = this.props.dotClickContext.position;
     const newContext = { ...this.props.dotClickContext };
-
     const dates = this.fetchDotPositions(newContext.parent, newContext.rowName, true, true);
     const currDateIndex = dates.findIndex((elt) => elt.date === newContext.date);
 
@@ -431,7 +428,6 @@ class StandardFilters extends React.PureComponent {
     const { dotClickContext } = this.props;
     const matchContext = dotClickContext && (parent === 'CategoryRollup' || parent === 'ProviderRollup' || parent === 'TimeWidget'
         || (dotClickContext.parent === parent && dotClickContext.rowName === rowName));
-
     const inactiveHighlightDots = this.props.allowDotClick && matchContext && allDates.reduce((res, elt) =>
     //               ((!isEnabled || !this.isActiveTimeWidget(elt)) && elt.position === dotClickContext.position)
       (((!isEnabled || !this.isActive(elt)) && elt.position === dotClickContext.position)

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -109,11 +109,11 @@ class StandardFilters extends React.PureComponent {
     }
 
     if (
-        prevState.minActivePos !== this.state.minActivePos
+      prevState.minActivePos !== this.state.minActivePos
         || prevState.maxActivePos !== this.state.maxActivePos
         || notEqJSON(prevProps.activeCategories, this.props.activeCategories)
         || notEqJSON(prevProps.activeProviders, this.props.activeProviders)
-      ) {
+    ) {
       this.setState({ activeDates: this.calcActiveDates() }); // problem with green dots not showing up is because this.calcActiveDates() doesn't fire on initial load
     }
 
@@ -156,7 +156,6 @@ class StandardFilters extends React.PureComponent {
         activeDates[dateOnly(res.itemDate)] = true;
       }
     }
-    console.log('activeDates', activeDates)
     return activeDates;
   }
 
@@ -186,10 +185,9 @@ class StandardFilters extends React.PureComponent {
   // Is 'dot':  (1) in the TimeWidget's active range
   //    (2) associated with an active Category
   //    (3) associated with an active Provider
-  isActive = (dot) => {
+  isActive = (dot) =>
     // console.log('this.state.activeDates', this.state.activeDates)
-    return(this.state.activeDates[dateOnly(dot.date)])
-  }
+    (this.state.activeDates[dateOnly(dot.date)])
 
   //
   // Mark a position-scaled copy of this dot with 'dotType' and include in result array

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -108,11 +108,13 @@ class StandardFilters extends React.PureComponent {
       this.updateSvgWidth();
     }
 
-    if (prevState.minActivePos !== this.state.minActivePos
-      || prevState.maxActivePos !== this.state.maxActivePos
-      || notEqJSON(prevProps.activeCategories, this.props.activeCategories)
-      || notEqJSON(prevProps.activeProviders, this.props.activeProviders)) {
-      this.setState({ activeDates: this.calcActiveDates() });
+    if (
+        prevState.minActivePos !== this.state.minActivePos
+        || prevState.maxActivePos !== this.state.maxActivePos
+        || notEqJSON(prevProps.activeCategories, this.props.activeCategories)
+        || notEqJSON(prevProps.activeProviders, this.props.activeProviders)
+      ) {
+      this.setState({ activeDates: this.calcActiveDates() }); // problem with green dots not showing up is because this.calcActiveDates() doesn't fire on initial load
     }
 
     if (prevProps.lastEvent !== this.props.lastEvent) {
@@ -154,6 +156,7 @@ class StandardFilters extends React.PureComponent {
         activeDates[dateOnly(res.itemDate)] = true;
       }
     }
+    console.log('activeDates', activeDates)
     return activeDates;
   }
 
@@ -183,7 +186,10 @@ class StandardFilters extends React.PureComponent {
   // Is 'dot':  (1) in the TimeWidget's active range
   //    (2) associated with an active Category
   //    (3) associated with an active Provider
-  isActive = (dot) => this.state.activeDates[dateOnly(dot.date)]
+  isActive = (dot) => {
+    // console.log('this.state.activeDates', this.state.activeDates)
+    return(this.state.activeDates[dateOnly(dot.date)])
+  }
 
   //
   // Mark a position-scaled copy of this dot with 'dotType' and include in result array
@@ -291,6 +297,7 @@ class StandardFilters extends React.PureComponent {
     const thumbDistance = this.state.maxActivePos - this.state.minActivePos;
     const oldPosition = this.props.dotClickContext.position;
     const newContext = { ...this.props.dotClickContext };
+
     const dates = this.fetchDotPositions(newContext.parent, newContext.rowName, true, true);
     const currDateIndex = dates.findIndex((elt) => elt.date === newContext.date);
 
@@ -426,6 +433,7 @@ class StandardFilters extends React.PureComponent {
     const { dotClickContext } = this.props;
     const matchContext = dotClickContext && (parent === 'CategoryRollup' || parent === 'ProviderRollup' || parent === 'TimeWidget'
         || (dotClickContext.parent === parent && dotClickContext.rowName === rowName));
+
     const inactiveHighlightDots = this.props.allowDotClick && matchContext && allDates.reduce((res, elt) =>
     //               ((!isEnabled || !this.isActiveTimeWidget(elt)) && elt.position === dotClickContext.position)
       (((!isEnabled || !this.isActive(elt)) && elt.position === dotClickContext.position)

--- a/src/css/Colors.css
+++ b/src/css/Colors.css
@@ -31,6 +31,7 @@
 
   /* Gray Tint (GT) */
   --gt1: rgb(233, 237, 244);             /* Blue Gray Light */
+  --gt1-dot: rgb(205, 208, 212);             /* Blue Gray Light */
   --gt1-40: rgba(233, 237, 244, 0.4);     /* Blue Gray Light */
   --gt2: rgb(124, 130, 143);             /* Blue Gray Medium */
   --gt3: rgb(166, 183, 217);             /* Blue Gray Medium Dark */
@@ -100,7 +101,7 @@
   --background-data: var(--co1);
   --background-accent: var(--ca1);
   --background-annotation: var(--gt1-40);
-  --background-timeline: var(--gt7);
+  --background-timeline: var(--white);
   --background-timeline-selector: var(--gn4-50);
   --background-scrollbar-thumb: var(--gt4);
   --background-scrollbar-thumb-hover: var(--gn5);
@@ -230,7 +231,7 @@
   --dots-active-highlight-stroke: var(--white);
   --dots-active-highlight-search: var();
   --dots-active-highlight-search-stroke: var(--white);
-  --dots-inactive: var(--gn4-15);
+  --dots-inactive: var(--gt1-dot);
   --dots-inactive-stroke: var(--white);
   --dots-content-inactive: var(--gn4-25);
   --dots-content-inactive-stroke: var(--white);

--- a/src/css/Colors.css
+++ b/src/css/Colors.css
@@ -31,7 +31,7 @@
 
   /* Gray Tint (GT) */
   --gt1: rgb(233, 237, 244);             /* Blue Gray Light */
-  --gt1-dot: rgb(205, 208, 212);             /* Blue Gray Light */
+  --gt1-dot: rgb(176, 179, 182);             /* Blue Gray Light */
   --gt1-40: rgba(233, 237, 244, 0.4);     /* Blue Gray Light */
   --gt2: rgb(124, 130, 143);             /* Blue Gray Medium */
   --gt3: rgb(166, 183, 217);             /* Blue Gray Medium Dark */
@@ -223,7 +223,7 @@
   --border-accent: var(--ca1);
 
   /* FILL COLOR MAPS */
-  --dots-active: var(--ca2-70);
+  --dots-active: var(--gt1-dot);
   --dots-active-stroke: var(--white);
   --dots-active-search: var(--cr4);
   --dots-active-search-stroke: var(--white);
@@ -231,7 +231,7 @@
   --dots-active-highlight-stroke: var(--white);
   --dots-active-highlight-search: var();
   --dots-active-highlight-search-stroke: var(--white);
-  --dots-inactive: var(--gt1-dot);
+  --dots-inactive: var(--gn1);
   --dots-inactive-stroke: var(--white);
   --dots-content-inactive: var(--gn4-25);
   --dots-content-inactive-stroke: var(--white);


### PR DESCRIPTION
needs `update-card-layout` to merge

Update timeline styles
- white background
- active dots should be the same color as cards

Issues
- Timeline does not recognize that any of the dots are 'Active' on initial load, even though they are within the 'All' time frame. Clicking on a different time frame cause the dots to render correctly. Also clicking on 'All' after a different timeline, renders the dots correctly.
- We may consider merge in this branch despite ^

![image](https://user-images.githubusercontent.com/45667486/106964178-b7c14880-670f-11eb-9de1-6f650b595808.png)
