### PR TITLE
Include dosage information in meds card

### DIFF
--- a/src/components/cards/MedicationCardBody.js
+++ b/src/components/cards/MedicationCardBody.js
@@ -14,7 +14,9 @@ const MedicationCardBody = ({ fieldsData }) => {
       const { period } = fieldsData.dosageInstruction.timing.repeat;
       // DSTU2 / STU3 compatibility
       const { periodUnit, periodUnits } = fieldsData.dosageInstruction.timing.repeat;
-      return `${frequency} every ${period} ${periodUnit || periodUnits} ${asNeededText}`; // need dynamic translation for
+      const { value, unit, code } = fieldsData.dosageInstruction.doseQuantity;
+
+      return `${frequency} doses of ${value}${unit || code} every ${period} ${periodUnit || periodUnits} ${asNeededText}`; // need dynamic translation for
     }
     return null;
   }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/110988/107513083-00fa1800-6ba8-11eb-9297-52f54c0857ed.png)


After:
![image](https://user-images.githubusercontent.com/110988/107513036-f17acf00-6ba7-11eb-9566-4f349ae5c955.png)

Attempted to fix this using https://github.com/sync-for-science/discovery-web-ui/pull/27, but honestly: in the end a localised function for the context is the way to go.

This version of the function is not foul-proof however and will display dodgy text if the data isn't shaped exactly as we'd like it to be. This is something we should improve in the future.