### PR TITLE
make CatalogView respond to timeline filter

### DIFF
--- a/src/components/CatalogView/CatalogView.css
+++ b/src/components/CatalogView/CatalogView.css
@@ -136,10 +136,6 @@
 .tiles-view-container-inner {
   display: flex;
   flex-direction: row;
-  /*width: 100%;*/
-  /*height: 100%;*/
-  /*overflow-x: hidden;*/
-  /*overflow-y: hidden;*/
   margin: 16px;
   margin-top: 0px;
   background-color: var(--tile-area);

--- a/src/components/CatalogView/CatalogView.css
+++ b/src/components/CatalogView/CatalogView.css
@@ -136,10 +136,12 @@
 .tiles-view-container-inner {
   display: flex;
   flex-direction: row;
-  width: 100%;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: hidden;
+  /*width: 100%;*/
+  /*height: 100%;*/
+  /*overflow-x: hidden;*/
+  /*overflow-y: hidden;*/
+  margin: 16px;
+  margin-top: 0px;
   background-color: var(--tile-area);
 }
 

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -146,14 +146,7 @@ class CompareView extends React.PureComponent {
 
     return (
       <div className="tiles-view">
-        <div className="tiles-view-header">
-          <div
-            className={tileSelected ? 'tiles-view-header-button-clear-selected' : 'tiles-view-header-button-clear'}
-            onClick={this.onClearClick}
-          >
-            Clear
-          </div>
-        </div>
+        <div className="tiles-view-header" />
         <div className="tiles-view-container">
           { enablededCategoryCount > 0 && (
             <div className="tiles-view-nav-left">

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -78,38 +78,14 @@ class CompareView extends React.PureComponent {
     return cols;
   }
 
-  onNavClick = (_dir) => {
-  }
-
   render() {
-    const { filteredActiveCollection } = this.props;
-
-    const enablededCategoryCount = Object.values(filteredActiveCollection).reduce((acc, category) => (category.totalCount ? (acc + 1) : acc), 0);
-
-    const maxFirstTileColNum = enablededCategoryCount - Math.trunc(this.state.numVisibleCols);
-
     return (
       <div className="tiles-view">
         <div className="tiles-view-header" />
         <div className="tiles-view-container">
-          { enablededCategoryCount > 0 && (
-            <div className="tiles-view-nav-left">
-              <button
-                className={this.state.firstTileColNum > 0 ? 'tiles-view-nav-left-button-on' : 'tiles-view-nav-left-button-off'}
-              />
-            </div>
-          ) }
           <div className="tiles-view-container-inner">
             { this.renderTileColumns() }
           </div>
-          { enablededCategoryCount > 0 && (
-            <div className="tiles-view-nav-right">
-              <button
-                className={this.state.firstTileColNum < maxFirstTileColNum ? 'tiles-view-nav-right-button-on' : 'tiles-view-nav-right-button-off'}
-                onClick={() => this.onNavClick('right')}
-              />
-            </div>
-          ) }
         </div>
         <SelectedCardCollection />
       </div>

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -82,33 +82,35 @@ class CompareView extends React.PureComponent {
 
   renderTileColumns() {
     const { filteredActiveCollection } = this.props;
-    const cols = Object.entries(filteredActiveCollection).reduce((acc, [categoryLabel, category]) => {
-      if (category?.filteredRecordCount) {
-        acc.push(
-          <div className={`${this.hyphenate(categoryLabel)} tiles-view-column-container`} key={categoryLabel}>
-            <div className="tiles-view-column-header">
-              {categoryLabel}
-              {/* <button className={this.buttonClass(categoryLabel)} onClick={() => this.handleSetClearButtonClick(categoryLabel)} /> */}
-            </div>
-            <div className="tiles-view-column-content">
-              { Object.entries(category.subtypes)
-                .sort(([subtype1], [subtype2]) => ((subtype1 < subtype2) ? -1 : 1))
-                .reduce((acc, [displayCoding, { uuids, _collectionUuids }]) => {
-                  if (uuids.length) {
-                    acc.push(<RecordSelector
-                      key={displayCoding}
-                      label={displayCoding}
-                      uuids={uuids}
-                    />);
-                  }
-                  return acc;
-                }, []) }
-            </div>
-          </div>,
-        );
-      }
-      return acc;
-    }, []);
+    const cols = Object.entries(filteredActiveCollection)
+      .sort(([categoryLabel1], [categoryLabel2]) => ((categoryLabel1 < categoryLabel2) ? -1 : 1))
+      .reduce((acc, [categoryLabel, category]) => {
+        if (category?.filteredRecordCount) {
+          acc.push(
+            <div className={`${this.hyphenate(categoryLabel)} tiles-view-column-container`} key={categoryLabel}>
+              <div className="tiles-view-column-header">
+                {categoryLabel}
+                {/* <button className={this.buttonClass(categoryLabel)} onClick={() => this.handleSetClearButtonClick(categoryLabel)} /> */}
+              </div>
+              <div className="tiles-view-column-content">
+                { Object.entries(category.subtypes)
+                  .sort(([subtype1], [subtype2]) => ((subtype1 < subtype2) ? -1 : 1))
+                  .reduce((acc, [displayCoding, { uuids, _collectionUuids }]) => {
+                    if (uuids.length) {
+                      acc.push(<RecordSelector
+                        key={displayCoding}
+                        label={displayCoding}
+                        uuids={uuids}
+                      />);
+                    }
+                    return acc;
+                  }, []) }
+              </div>
+            </div>,
+          );
+        }
+        return acc;
+      }, []);
 
     if (cols.length === 0) {
       cols.push(

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -11,28 +11,31 @@ import {
   filteredActiveCollectionState,
 } from '../../recoil';
 
+const noneEnabled = (obj) => Object.values(obj).reduce((acc, isEnabled) => (isEnabled ? false : acc), true);
+
+const NoResultsDisplay = React.memo(({ filteredRecordCount, activeCategories, activeProviders }) => {
+  if (filteredRecordCount) {
+    return null;
+  }
+
+  let message = 'No data found for the selected Records, Providers, and Time period';
+  if (noneEnabled(activeCategories)) {
+    message = 'No Record type is selected';
+  } else if (noneEnabled(activeProviders)) {
+    message = 'No Provider is selected';
+  }
+
+  return (
+    <div className="tiles-view-container-inner-empty" key="1">
+      { message }
+    </div>
+  );
+});
+
 class CompareView extends React.PureComponent {
   state = {
     firstTileColNum: 0,
     numVisibleCols: 0,
-  }
-
-  noneEnabled(obj) {
-    for (const propName of Object.keys(obj)) {
-      if (obj[propName]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  get noResultDisplay() {
-    if (this.noneEnabled(this.props.activeCategories)) {
-      return 'No Record type is selected';
-    } if (this.noneEnabled(this.props.activeProviders)) {
-      return 'No Provider is selected';
-    }
-    return this.props.noResultDisplay ? this.props.noResultDisplay : 'No data found for the selected Records, Providers, and Time period';
   }
 
   renderTileColumns() {
@@ -67,24 +70,22 @@ class CompareView extends React.PureComponent {
         return acc;
       }, []);
 
-    if (cols.length === 0) {
-      cols.push(
-        <div className="tiles-view-container-inner-empty" key="1">
-          { this.noResultDisplay }
-        </div>,
-      );
-    }
-
     return cols;
   }
 
   render() {
+    const { activeCategories, activeProviders, filteredActiveCollection: { filteredRecordCount } } = this.props;
     return (
       <div className="tiles-view">
         <div className="tiles-view-header" />
         <div className="tiles-view-container">
           <div className="tiles-view-container-inner">
             { this.renderTileColumns() }
+            <NoResultsDisplay
+              filteredRecordCount={filteredRecordCount}
+              activeCategories={activeCategories}
+              activeProviders={activeProviders}
+            />
           </div>
         </div>
         <SelectedCardCollection />

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -13,11 +13,11 @@ import {
 class CompareView extends React.PureComponent {
   static propTypes = {
     groupedRecordIdsBySubtype: PropTypes.shape({}),
-    resources: PropTypes.shape({
-      patient: PropTypes.shape({}),
-      providers: PropTypes.arrayOf(PropTypes.string),
-      legacy: PropTypes.instanceOf(FhirTransform),
-    }),
+    // resources: PropTypes.shape({
+    //   patient: PropTypes.shape({}),
+    //   providers: PropTypes.arrayOf(PropTypes.string),
+    //   legacy: PropTypes.instanceOf(FhirTransform),
+    // }),
     totalResCount: PropTypes.number,
     categories: PropTypes.arrayOf(PropTypes.string).isRequired,
     providers: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -30,14 +30,14 @@ class CompareView extends React.PureComponent {
 
   state = {
     firstTileColNum: 0,
-    leftColNavEnabled: true,
-    rightColNavEnabled: true,
+    // leftColNavEnabled: true,
+    // rightColNavEnabled: true,
     uniqueStruct: {},
     numVisibleCols: 0,
     selectedTiles: {},
-    lastTileSelected: null,
-    topBound: 0,
-    onlyMultisource: false,
+    // lastTileSelected: null,
+    // topBound: 0,
+    // onlyMultisource: false,
   }
 
   // onResize = () => {

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -91,10 +91,6 @@ class CompareView extends React.PureComponent {
     // }
   }
 
-  onClearClick = () => {
-    console.error('TODO: onClearClick: re-implement via recoil'); // eslint-disable-line no-console
-  }
-
   render() {
     const { filteredActiveCollection } = this.props;
 

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -1,31 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useRecoilValue } from 'recoil';
 
 import './CatalogView.css';
-import { useRecoilValue } from 'recoil';
-import config from '../../config.js';
-import { log } from '../../utils/logger';
-import {
-  Const, getStyle, tryWithDefault, numericPart, inDateRange, uniqueBy, notEqJSON, classFromCat,
-} from '../../util.js';
 import FhirTransform from '../../FhirTransform.js';
-import { primaryTextValue } from '../../fhirUtil.js';
-
-import Unimplemented from '../Unimplemented';
 import SelectedCardCollection from '../SelectedCardCollection';
 import RecordSelector from '../SelectedCardCollection/RecordSelector';
-
-import DiscoveryContext from '../DiscoveryContext';
 import {
   groupedRecordIdsBySubtypeState,
 } from '../../recoil';
 
-//
-// Render the "tiles view" of the participant's data
-//
 class CompareView extends React.PureComponent {
-  static contextType = DiscoveryContext; // Allow the shared context to be accessed via 'this.context'
-
   static propTypes = {
     groupedRecordIdsBySubtype: PropTypes.shape({}),
     resources: PropTypes.shape({
@@ -34,16 +19,6 @@ class CompareView extends React.PureComponent {
       legacy: PropTypes.instanceOf(FhirTransform),
     }),
     totalResCount: PropTypes.number,
-    dates: PropTypes.shape({
-      allDates: PropTypes.arrayOf(PropTypes.shape({
-        position: PropTypes.number.isRequired,
-        date: PropTypes.string.isRequired,
-      })).isRequired,
-      minDate: PropTypes.string.isRequired, // Earliest date we have data for this participant
-      startDate: PropTypes.string.isRequired, // Jan 1 of minDate's year
-      maxDate: PropTypes.string.isRequired, // Latest date we have data for this participant
-      endDate: PropTypes.string.isRequired, // Dec 31 of last year of timeline tick periods
-    }),
     categories: PropTypes.arrayOf(PropTypes.string).isRequired,
     providers: PropTypes.arrayOf(PropTypes.string).isRequired,
     catsEnabled: PropTypes.object.isRequired,
@@ -65,483 +40,12 @@ class CompareView extends React.PureComponent {
     onlyMultisource: false,
   }
 
-  componentDidMount() {
-    window.addEventListener('resize', this.onResize);
-
-    if (this.context.savedSelectedTiles) {
-      this.setState({ selectedTiles: this.context.savedSelectedTiles });
-      this.context.updateGlobalContext({ viewAccentDates: this.viewAccentDatesFromSelected(this.context.savedSelectedTiles) });
-    }
-
-    if (this.context.lastTileSelected) {
-      const last = this.context.lastTileSelected;
-      this.setState({ lastTileSelected: last });
-
-      const lastResources = this.matchingTileResources(last);
-      this.context.updateGlobalContext({
-        lastHighlightedResources: lastResources,
-        viewLastAccentDates: this.uniqueDatesFromResources(lastResources),
-      });
-    }
-
-    this.setState({ onlyMultisource: this.context.onlyMultisource },
-      () => this.setState({ uniqueStruct: this.buildUniqueStruct() },
-        () => this.setState({ numVisibleCols: this.numVisibleCols() })));
-  }
-
-  componentWillUnmount() {
-    this.context.updateGlobalContext({
-      savedSelectedTiles: this.state.selectedTiles,
-      lastTileSelected: this.state.lastTileSelected, // Save selected tiles, last tile selected
-      viewAccentDates: [],
-      viewLastAccentDates: [],
-      highlightedResources: [],
-      lastHighlightedResources: [],
-    }); // Clear highlights
-
-    window.removeEventListener('resize', this.onResize);
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    // debugger;
-    // TODO: only on explicit changes?
-    if (notEqJSON(prevProps, this.props) || prevState.onlyMultisource !== this.state.onlyMultisource) {
-      this.setState({ uniqueStruct: this.buildUniqueStruct() },
-        () => this.setState({ firstTileColNum: 0, numVisibleCols: this.numVisibleCols() }));
-    }
-
-    // TODO: only on explicit changes?
-    if (notEqJSON(prevState, this.state)) {
-      const container = document.querySelector('.tiles-view-container');
-      const header = document.querySelector('.tiles-view-column-header');
-      if (container && header) {
-        this.setState({ topBound: numericPart(getStyle(container, 'margin-top')) + header.clientHeight });
-      }
-    }
-
-    // Kluge: get saved tile state if not set in mount (and then clear)
-    if (this.context.savedSelectedTiles && Object.keys(this.context.savedSelectedTiles).length > 0
-      && this.state.selectedTiles && Object.keys(this.state.selectedTiles).length === 0) {
-      this.setState({ selectedTiles: this.context.savedSelectedTiles });
-      this.context.updateGlobalContext({
-        viewAccentDates: this.viewAccentDatesFromSelected(this.context.savedSelectedTiles),
-        savedSelectedTiles: {},
-      });
-    }
-
-    if (this.context.lastTileSelected && !this.state.lastTileSelected) {
-      const last = this.context.lastTileSelected;
-      this.setState({ lastTileSelected: last });
-
-      const lastResources = this.matchingTileResources(last);
-      this.context.updateGlobalContext({
-        lastHighlightedResources: lastResources,
-        viewLastAccentDates: this.uniqueDatesFromResources(lastResources),
-        lastTileSelected: null,
-      });
-    }
-  }
-
-  onResize = () => {
-    this.setState({ numVisibleCols: this.numVisibleCols() });
-  }
-
-  contentPanelBottomBound() {
-    try {
-      const footTop = document.querySelector('.page-footer').getBoundingClientRect().top;
-      const headerBot = document.querySelector('.time-widget').getBoundingClientRect().bottom;
-      const contentPanelTitleHeight = document.querySelector('.content-panel-inner-title').clientHeight;
-
-      return footTop - headerBot - contentPanelTitleHeight - 10; // TODO: correct margin size
-    } catch (e) {
-      return 0;
-    }
-  }
-
-  initialPositionY() {
-    const container = document.querySelector('.tiles-view-container');
-    const tilesView = document.querySelector('.tiles-view');
-
-    // Reset any prior size adjustment
-    container.style = 'height:""';
-
-    if (container.clientHeight > tilesView.clientHeight / 1.6) {
-      container.style = `height:${tilesView.clientHeight / 1.6}px;`;
-    }
-
-    return container.clientHeight + 25; // TODO: correct margin sizes
-  }
-
-  onContentPanelResize() {
-    const tilesViewHeight = document.querySelector('.tiles-view').clientHeight;
-    const contentPanelHeight = document.querySelector('.content-panel-tiles-view').clientHeight;
-    const container = document.querySelector('.tiles-view-container');
-    //      console.log('RESIZE tiles-view-container: ' + (tilesViewHeight - contentPanelHeight - 5));
-    container.style = `height:${tilesViewHeight - contentPanelHeight - 5}px;`;
-  }
-
-  getCoding(res) {
-    const codeObj = classFromCat(res.category).code(res);
-    const code = tryWithDefault(codeObj, (codeObj) => codeObj.coding[0].code, tryWithDefault(codeObj, (codeObj) => codeObj.code, '????'));
-    const display = primaryTextValue(codeObj);
-    return { code, display: display === Const.unknownValue ? `All ${res.category}` : display };
-  }
-
-  // Categories we DON'T want to collect  [FROM CompareView]
-  get noCollectCategories() {
-    return ['Patient'];
-  }
-
-  //
-  // collectUnique()    [DERIVED FROM CompareView]
-  //
-  // Resulting structure ('struct'):
-  // {
-  //  cat1: [
-  //      {
-  //         display: 'disp1',
-  //         trueCategory: 'category',
-  //         codes: ['code1', 'code2', ...],
-  //         provs: [
-  //            {
-  //               provName: 'prov1',
-  //               count: count1,
-  //        minDate: 'date1',
-  //        maxDate: 'date2',
-  //        dates: [ {x: 'date', y: 0}, ... ]
-  //            },
-  //            ...
-  //         ]
-  //      },
-  //      ...
-  //   ],
-  //   ...
+  // onResize = () => {
+  //   this.setState({ numVisibleCols: this.numVisibleCols() });
   // }
-  //
-  collectUnique(struct, cat, prov) {
-    const { legacy } = this.props.resources;
-    const resources = cat === Unimplemented.catName ? legacy.transformed.filter((res) => Unimplemented.unimplementedCats.includes(res.category)
-      && res.provider === prov)
-      : legacy.pathItem(`[*category=${cat}][*provider=${prov}]`);
-    for (const res of resources) {
-      if (this.noCollectCategories.includes(res.category)
-        || !inDateRange(res.itemDate, this.props.thumbLeftDate, this.props.thumbRightDate)) {
-        continue; // Ignore this resource
-      }
-
-      if (!struct.hasOwnProperty(cat)) {
-        // Add this category
-        struct[cat] = [];
-        //      console.log('1 ' + cat + ' added');
-      }
-
-      const thisCat = struct[cat];
-      const coding = cat === Unimplemented.catName ? { code: res.category, display: `All ${res.category}` }
-        : this.getCoding(res);
-      const thisDisplay = thisCat.find((elt) => elt.display === coding.display);
-      const date = res.itemDate instanceof Date ? res.itemDate : new Date(res.itemDate);
-
-      if (thisDisplay) {
-        // Update previously added display value
-        const { provs } = thisDisplay;
-        const thisProv = provs.find((elt) => elt.provName === prov);
-        if (!thisDisplay.codes.includes(coding.code)) {
-          // Add this code to code list for this display value
-          thisDisplay.codes.push(coding.code);
-        }
-        if (thisProv) {
-          // Update previously added prov
-          thisProv.count++;
-          thisProv.minDate = date.getTime() < thisProv.minDate.getTime() ? date : thisProv.minDate;
-          thisProv.maxDate = date.getTime() > thisProv.maxDate.getTime() ? date : thisProv.maxDate;
-          thisProv.dates.push({ x: date, y: 0 });
-          //         console.log('2 ' + cat + ' ' + JSON.stringify(thisDisplay.codes) + ' ' + thisDisplay.display + ': ' + thisProv.provName + ' ' + thisProv.count);
-        } else {
-          // Add new prov
-          provs.push({
-            provName: prov, count: 1, minDate: date, maxDate: date, dates: [{ x: date, y: 0 }],
-          });
-          //         console.log('3 ' + cat + ' ' + JSON.stringify(thisDisplay.codes) + ' ' + thisDisplay.display + ': ' + prov + ' 1');
-        }
-      } else {
-        // Add new display value
-        thisCat.push({
-          display: coding.display,
-          trueCategory: res.category,
-          codes: [coding.code],
-          provs: [{
-            provName: prov, count: 1, minDate: date, maxDate: date, dates: [{ x: date, y: 0 }],
-          }],
-        });
-        //      console.log('4 ' + cat + ' ' + coding.code + ' ' + coding.display + ': ' + prov + ' 1');
-      }
-    }
-  }
-
-  buildUniqueStruct() {
-    const struct = {};
-    for (const catName of this.props.categories) {
-      if (this.props.catsEnabled[catName] !== false) {
-        for (const provName of this.props.providers) {
-          if (this.props.provsEnabled[provName] !== false) {
-            this.collectUnique(struct, catName, provName);
-          }
-        }
-      }
-    }
-
-    // Possibly prune if onlyMultisource
-    if (this.state.onlyMultisource) {
-      for (const cat in struct) {
-        const pruned = struct[cat].filter((elt) => elt.provs.length > 1);
-        if (pruned.length > 0) {
-          struct[cat] = pruned;
-        } else {
-          delete struct[cat];
-        }
-      }
-    }
-
-    return struct;
-  }
-
-  numVisibleCols() {
-    const container = document.querySelector('.tiles-view-container-inner');
-    if (!container) {
-      return 0;
-    }
-    const minFractionalColWidth = 15;
-    const numCols = Object.keys(this.state.uniqueStruct).length;
-    const colWidth = 175; // Values MUST match tiles-view-column-container width and margins (px)
-    const colRightMargin = 10;
-    const totalColWidth = colWidth + colRightMargin; // NOTE: DOM isn't fully built when we need this
-    const containerWidth = container.clientWidth + colRightMargin; // Browser doesn't "count" last margin
-    const visibleCols = containerWidth / totalColWidth;
-    const wholeCols = Math.trunc(visibleCols);
-    const fractionalCol = visibleCols - wholeCols;
-    const fractionalColWidth = fractionalCol * totalColWidth; // px
-    //   console.log('#### containerWidth: ' + containerWidth);
-    //   console.log('#### visibleCols:    ' + visibleCols.toFixed(3));
-    //   console.log('#### fracColWidth:   ' + fractionalColWidth.toFixed(3));
-
-    return Math.min(numCols, fractionalColWidth < minFractionalColWidth ? wholeCols : containerWidth / totalColWidth);
-  }
-
-  hyphenate(name) {
-    return name.toLowerCase().replace(/ /g, '-');
-  }
-
-  tileId(catName, display, trueCategory) {
-    return `${this.hyphenate(catName)} ${this.hyphenate(display)} ${trueCategory}`;
-  }
-
-  parseTileId(id) {
-    const idParts = id.split(' ');
-    return { catName: idParts[0], display: idParts[1], trueCategory: idParts.slice(2).join(' ') };
-  }
-
-  isTileSelected(catName, display) {
-    try {
-      return this.state.selectedTiles[catName][display];
-    } catch (e) {
-      return false;
-    }
-  }
-
-  isLastTileSelected(catName, display) {
-    return this.state.lastTileSelected && (this.state.lastTileSelected.catName === catName) && (this.state.lastTileSelected.display === display);
-  }
-
-  matchingTileResources(tileId) {
-    const { legacy } = this.props.resources;
-    let res = legacy.transformed.filter((res) => this.hyphenate(res.category) === tileId.catName
-      && this.hyphenate(this.getCoding(res).display) === tileId.display);
-    if (res.length === 0) {
-      // Kluge for 'other'
-      res = legacy.transformed.filter((res) => res.category === tileId.trueCategory);
-    }
-
-    return res;
-  }
-
-  // Get all resources from selectedUniqueItems
-  allSelectedTileResources(selectedTiles) {
-    let resArray = [];
-    for (const catName of Object.keys(selectedTiles)) {
-      for (const displayStr of Object.keys(selectedTiles[catName])) {
-        resArray = resArray.concat(selectedTiles[catName][displayStr]);
-      }
-    }
-
-    return resArray;
-  }
-
-  onTileClick(e) {
-    const newSelectedTiles = { ...this.state.selectedTiles }; // copy selected tiles obj
-    const tileId = this.parseTileId(e.target.id);
-    let matchingTileResources = null;
-    let clearedPrevSelected = false;
-
-    if (this.isTileSelected(tileId.catName, tileId.display)) {
-      if (Object.keys(newSelectedTiles[tileId.catName]).length === 1) {
-        // Delete category
-        delete newSelectedTiles[tileId.catName];
-      } else {
-        // Clear selection of the just-clicked tile
-        delete newSelectedTiles[tileId.catName][tileId.display];
-      }
-      clearedPrevSelected = true;
-      this.context.updateGlobalContext({
-        highlightedResources: [], // Used by HighlightDiv
-        lastHighlightedResources: [],
-      }); //
-      this.setState({ lastTileSelected: null });
-    } else {
-      // Select the clicked tile
-      if (!newSelectedTiles[tileId.catName]) {
-        newSelectedTiles[tileId.catName] = {};
-      }
-      matchingTileResources = this.matchingTileResources(tileId);
-      newSelectedTiles[tileId.catName][tileId.display] = matchingTileResources;
-      this.context.updateGlobalContext({
-        highlightedResources: this.allSelectedTileResources(newSelectedTiles), // Used by HighlightDiv
-        lastHighlightedResources: matchingTileResources,
-      }); //
-      //   let newDate = matchingTileResources[0].itemDate;
-      //   let newContext = Object.assign(this.state.context, { date: newDate,
-      //                    position: normalizeDates([newDate], this.state.context.minDate, this.state.context.maxDate)[0],
-      //                    dotType: 'active' });
-      this.setState({
-        lastTileSelected: tileId,
-        //       context: newContext
-      });
-    }
-
-    // If all/no tiles are now selected for this category, clear lastSavedSelectedTiles for this category
-    const selectedTilesForCatCount = newSelectedTiles[tileId.catName] ? Object.keys(newSelectedTiles[tileId.catName]).length : 0;
-    // TODO: following is inefficient -- consider converting uniqueStruct to use "hyphenated" category names
-    const tilesForCatCount = this.state.uniqueStruct[Object.keys(this.state.uniqueStruct).find((key) => this.hyphenate(key) === tileId.catName)].length;
-    if (this.context.lastSavedSelectedTiles && (selectedTilesForCatCount === 0 || selectedTilesForCatCount === tilesForCatCount)) {
-      const newLastSavedSelectedTiles = { ...this.context.lastSavedSelectedTiles };
-      delete newLastSavedSelectedTiles[tileId.catName];
-      this.context.updateGlobalContext({ lastSavedSelectedTiles: newLastSavedSelectedTiles });
-    }
-
-    this.setState({ selectedTiles: newSelectedTiles });
-    this.context.updateGlobalContext({
-      viewAccentDates: this.viewAccentDatesFromSelected(newSelectedTiles),
-      viewLastAccentDates: clearedPrevSelected ? [] : this.uniqueDatesFromResources(this.matchingTileResources(tileId)),
-    });
-
-    // Scroll to the latest resource of the clicked tile
-    // if (matchingTileResources) {
-    //   const latest = matchingTileResources.reduce((latest, elt) => (new Date(elt.itemDate) > new Date(latest.itemDate) ? elt : latest),
-    //     matchingTileResources[0]);
-    //   // Delay a bit to allow resources to be rendered to the DOM
-    //   setTimeout((res) => {
-    //     const key = fhirKey(res);
-    //     const elt = document.querySelector(`[data-fhir="${key}"]`);
-    //     if (elt) {
-    //       elt.scrollIntoView();
-    //     } else {
-    //       console.log(`onTileClick(): cannot scroll to "${key}"`);
-    //     }
-    //   }, 200, latest);
-    // }
-  }
-
-  // Get unique dates from resources
-  uniqueDatesFromResources(resArray) {
-    const dates = resArray.reduce((acc, res) => { acc.push(res.itemDate); return acc; }, []);
-    return uniqueBy(dates, (elt) => elt);
-  }
-
-  // Get unique dates from selectedTiles
-  // TODO: delete & replace calls with uniqueDatesFromResources(allSelectedTileResources(selectedTiles))
-  viewAccentDatesFromSelected(selectedTiles) {
-    let dateArray = [];
-    if (selectedTiles) {
-      for (const catName of Object.keys(selectedTiles)) {
-        for (const displayStr of Object.keys(selectedTiles[catName])) {
-          dateArray = dateArray.concat(selectedTiles[catName][displayStr].reduce((acc, res) => { acc.push(res.itemDate); return acc; }, []));
-        }
-      }
-    }
-
-    return uniqueBy(dateArray, (elt) => elt);
-  }
 
   handleSetClearButtonClick = (catName) => {
-    const hCatName = this.hyphenate(catName);
-    const selectedTilesForCat = this.state.selectedTiles[hCatName];
-    const selectedCount = selectedTilesForCat ? Object.keys(selectedTilesForCat).length : 0;
-    const tilesForCatCount = this.state.uniqueStruct[catName].length;
-    let newSelectedTiles = null;
-
-    if (selectedCount === 0) {
-      // None selected
-      if (this.context.lastSavedSelectedTiles && this.context.lastSavedSelectedTiles[hCatName]) {
-        // --> prior saved partial
-        this.setState({ selectedTiles: this.context.lastSavedSelectedTiles });
-        this.context.updateGlobalContext({ viewAccentDates: this.viewAccentDatesFromSelected(this.context.lastSavedSelectedTiles) });
-      } else {
-        // --> all selected
-        newSelectedTiles = { ...this.state.selectedTiles }; // copy selected tiles obj
-        if (!newSelectedTiles[hCatName]) {
-          newSelectedTiles[hCatName] = {};
-        }
-        for (const tile1 of this.state.uniqueStruct[catName]) {
-          const hDisplay1 = this.hyphenate(tile1.display);
-          newSelectedTiles[hCatName][hDisplay1] = this.matchingTileResources({ catName: hCatName, display: hDisplay1, trueCategory: tile1.trueCategory });
-        }
-        this.setState({ selectedTiles: newSelectedTiles });
-        this.context.updateGlobalContext({ viewAccentDates: this.viewAccentDatesFromSelected(newSelectedTiles) });
-      }
-    } else if (selectedCount < tilesForCatCount) {
-      // Part selected --> all selected (and save copy of partial)
-      this.context.updateGlobalContext({ lastSavedSelectedTiles: JSON.parse(JSON.stringify(this.state.selectedTiles)) });
-      newSelectedTiles = { ...this.state.selectedTiles }; // copy selected tiles obj
-      if (!newSelectedTiles[hCatName]) {
-        newSelectedTiles[hCatName] = {};
-      }
-      for (const tile2 of this.state.uniqueStruct[catName]) {
-        const hDisplay2 = this.hyphenate(tile2.display);
-        newSelectedTiles[hCatName][hDisplay2] = this.matchingTileResources({ catName: hCatName, display: hDisplay2, trueCategory: tile2.trueCategory });
-      }
-      this.setState({ selectedTiles: newSelectedTiles });
-      this.context.updateGlobalContext({
-        viewAccentDates: this.viewAccentDatesFromSelected(newSelectedTiles),
-        viewLastAccentDates: [],
-      });
-      // Clear lastTileSelected if matches
-      if (this.state.lastTileSelected && this.state.lastTileSelected.catName === hCatName) {
-        this.context.updateGlobalContext({ highlightedResources: [] });
-        this.setState({ lastTileSelected: null });
-      }
-    } else {
-      // All selected --> none selected
-      newSelectedTiles = { ...this.state.selectedTiles }; // copy selected tiles obj
-      delete newSelectedTiles[hCatName];
-      this.setState({ selectedTiles: newSelectedTiles });
-      this.context.updateGlobalContext({
-        viewAccentDates: this.viewAccentDatesFromSelected(newSelectedTiles),
-        viewLastAccentDates: [],
-      });
-      // Clear lastTileSelected if matches
-      if (this.state.lastTileSelected && this.state.lastTileSelected.catName === hCatName) {
-        this.context.updateGlobalContext({ highlightedResources: [] });
-        this.setState({ lastTileSelected: null });
-      }
-    }
-  }
-
-  tileClassName(catName, display) {
-    if (this.isLastTileSelected(catName, display)) {
-      return 'tile-standard-last';
-    } if (this.isTileSelected(catName, display)) {
-      return 'tile-standard-selected';
-    }
-    return 'tile-standard';
+    console.error(`TODO: handleSetClearButtonClick(${catName}): re-impliment via recoil`); // eslint-disable-line no-console
   }
 
   buttonClass(catName) {
@@ -555,9 +59,6 @@ class CompareView extends React.PureComponent {
   }
 
   noneEnabled(obj) {
-    // if (!obj) {
-    //   return true;
-    // }
     for (const propName of Object.keys(obj)) {
       if (obj[propName]) {
         return false;
@@ -578,16 +79,10 @@ class CompareView extends React.PureComponent {
   renderTiles(catName) {
     const { groupedRecordIdsBySubtype } = this.props;
     const tiles = [];
-    // for (const catInst of this.state.uniqueStruct[catName].sort((a, b) => stringCompare(a.display, b.display))) {
     if (groupedRecordIdsBySubtype[catName]) {
       Object.entries(groupedRecordIdsBySubtype[catName].subtypes)
-        // .sort(([catName1], [catName2]) => (catName1 > catName2))
-        // .forEach(([catName, uuids]) => {
         .sort(([subtype1], [subtype2]) => ((subtype1 < subtype2) ? -1 : 1))
         .forEach(([displayCoding, uuids]) => {
-          // const tileIdStr = this.tileId(catName, catInst.display, catInst.trueCategory);
-          // const tileId = this.parseTileId(tileIdStr);
-          // const count = catInst.provs.reduce((accum, prov) => accum + prov.count, 0);
           tiles.push(<RecordSelector
             key={displayCoding}
             label={displayCoding}
@@ -626,23 +121,6 @@ class CompareView extends React.PureComponent {
     return cols;
   }
 
-  // Collect resources matching all selected tiles (plus Patient)
-  selectedTileResources() {
-    const { legacy } = this.props.resources;
-    let resArray = legacy.transformed.filter((elt) => elt.category === 'Patient');
-    for (const catName of Object.keys(this.state.selectedTiles)) {
-      for (const displayStr of Object.keys(this.state.selectedTiles[catName])) {
-        if (!this.state.onlyMultisource
-          || (this.state.onlyMultisource // more than one provider?
-            && this.state.selectedTiles[catName][displayStr].reduce((provs, res) => provs.add(res.provider), new Set()).size > 1)) {
-          resArray = resArray.concat(this.state.selectedTiles[catName][displayStr]);
-        }
-      }
-    }
-
-    return new FhirTransform(resArray, (data) => data);
-  }
-
   onNavClick = (dir) => {
     if (dir === 'left') {
       this.setState({ firstTileColNum: Math.max(0, this.state.firstTileColNum - 1) });
@@ -652,28 +130,13 @@ class CompareView extends React.PureComponent {
     }
   }
 
-  onlyMultisourceChange = (event) => {
-    //      console.log('multisource change: ' + event.target.checked);
-    this.setState({ onlyMultisource: event.target.checked });
-    this.context.updateGlobalContext({ onlyMultisource: event.target.checked });
-  }
-
   onClearClick = () => {
-    this.setState({
-      selectedTiles: {},
-      lastTileSelected: null,
-    });
-    this.context.updateGlobalContext({
-      viewAccentDates: [],
-      viewLastAccentDates: [],
-      highlightedResources: [],
-    });
+    console.error('TODO: onClearClick: re-implement via recoil'); // eslint-disable-line no-console
   }
 
   render() {
     const maxFirstTileColNum = Object.keys(this.state.uniqueStruct).length - Math.trunc(this.state.numVisibleCols);
     const tileSelected = Object.keys(this.state.selectedTiles).length > 0;
-    log(`numVis: ${this.state.numVisibleCols} maxFirst: ${maxFirstTileColNum} first: ${this.state.firstTileColNum}`);
     return (
       <div className="tiles-view">
         <div className="tiles-view-header">
@@ -683,12 +146,6 @@ class CompareView extends React.PureComponent {
           >
             Clear
           </div>
-          { config.enableReportedMultProvs && (
-          <label className="tiles-view-multisource-label">
-            <input className="tiles-view-multisource-check" type="checkbox" checked={this.state.onlyMultisource} onChange={this.onlyMultisourceChange} />
-            Reported by multiple providers
-          </label>
-          ) }
         </div>
         <div className="tiles-view-container">
           { Object.keys(this.state.uniqueStruct).length > 0 && (
@@ -697,7 +154,6 @@ class CompareView extends React.PureComponent {
               className={this.state.firstTileColNum > 0 ? 'tiles-view-nav-left-button-on' : 'tiles-view-nav-left-button-off'}
               onClick={() => this.onNavClick('left')}
             />
-            {/* this.state.firstTileColNum > 0 && <button className='tiles-view-nav-left-button-on' onClick={() => this.onNavClick('left')}/> */}
           </div>
           ) }
           <div className="tiles-view-container-inner">
@@ -709,8 +165,6 @@ class CompareView extends React.PureComponent {
               className={this.state.firstTileColNum < maxFirstTileColNum ? 'tiles-view-nav-right-button-on' : 'tiles-view-nav-right-button-off'}
               onClick={() => this.onNavClick('right')}
             />
-            {/* this.state.firstTileColNum < maxFirstTileColNum && <button className='tiles-view-nav-right-button-on'
-                     onClick={() => this.onNavClick('right')}/> */}
           </div>
           ) }
         </div>

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -17,9 +17,9 @@ class CompareView extends React.PureComponent {
     //   providers: PropTypes.arrayOf(PropTypes.string),
     //   legacy: PropTypes.instanceOf(FhirTransform),
     // }),
-    totalResCount: PropTypes.number,
-    categories: PropTypes.arrayOf(PropTypes.string).isRequired,
-    providers: PropTypes.arrayOf(PropTypes.string).isRequired,
+    // totalResCount: PropTypes.number,
+    // categories: PropTypes.arrayOf(PropTypes.string).isRequired,
+    // providers: PropTypes.arrayOf(PropTypes.string).isRequired,
     catsEnabled: PropTypes.object.isRequired,
     provsEnabled: PropTypes.object.isRequired,
     thumbLeftDate: PropTypes.string.isRequired,
@@ -31,7 +31,7 @@ class CompareView extends React.PureComponent {
     firstTileColNum: 0,
     // leftColNavEnabled: true,
     // rightColNavEnabled: true,
-    uniqueStruct: {},
+    // uniqueStruct: {},
     numVisibleCols: 0,
     // lastTileSelected: null,
     // topBound: 0,
@@ -121,13 +121,13 @@ class CompareView extends React.PureComponent {
     return cols;
   }
 
-  onNavClick = (dir) => {
-    if (dir === 'left') {
-      this.setState({ firstTileColNum: Math.max(0, this.state.firstTileColNum - 1) });
-    } else {
-      const maxFirstTileColNum = Object.keys(this.state.uniqueStruct).length - Math.trunc(this.state.numVisibleCols);
-      this.setState({ firstTileColNum: Math.min(maxFirstTileColNum, this.state.firstTileColNum + 1) });
-    }
+  onNavClick = (_dir) => {
+    // if (dir === 'left') {
+    //   this.setState({ firstTileColNum: Math.max(0, this.state.firstTileColNum - 1) });
+    // } else {
+    //   const maxFirstTileColNum = Object.keys(this.state.uniqueStruct).length - Math.trunc(this.state.numVisibleCols);
+    //   this.setState({ firstTileColNum: Math.min(maxFirstTileColNum, this.state.firstTileColNum + 1) });
+    // }
   }
 
   onClearClick = () => {

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -6,7 +6,10 @@ import './CatalogView.css';
 import SelectedCardCollection from '../SelectedCardCollection';
 import RecordSelector from '../SelectedCardCollection/RecordSelector';
 import {
+  activeCategoriesState,
+  activeProvidersState,
   filteredActiveCollectionState,
+  // timeFiltersState,
 } from '../../recoil';
 
 class CompareView extends React.PureComponent {
@@ -31,9 +34,9 @@ class CompareView extends React.PureComponent {
   }
 
   get noResultDisplay() {
-    if (this.noneEnabled(this.props.catsEnabled)) {
+    if (this.noneEnabled(this.props.activeCategories)) {
       return 'No Record type is selected';
-    } if (this.noneEnabled(this.props.provsEnabled)) {
+    } if (this.noneEnabled(this.props.activeProviders)) {
       return 'No Provider is selected';
     }
     return this.props.noResultDisplay ? this.props.noResultDisplay : 'No data found for the selected Records, Providers, and Time period';
@@ -130,28 +133,28 @@ class CompareView extends React.PureComponent {
 
 CompareView.propTypes = {
   filteredActiveCollection: PropTypes.shape({}),
-  // resources: PropTypes.shape({
-  //   patient: PropTypes.shape({}),
-  //   providers: PropTypes.arrayOf(PropTypes.string),
-  //   legacy: PropTypes.instanceOf(FhirTransform),
-  // }),
-  // totalResCount: PropTypes.number,
-  // categories: PropTypes.arrayOf(PropTypes.string).isRequired,
-  // providers: PropTypes.arrayOf(PropTypes.string).isRequired,
-  catsEnabled: PropTypes.object.isRequired,
-  provsEnabled: PropTypes.object.isRequired,
-  thumbLeftDate: PropTypes.string.isRequired,
-  thumbRightDate: PropTypes.string.isRequired,
-  // context, nextPrevFn added in StandardFilters
+  activeCategories: PropTypes.shape({}),
+  activeProviders: PropTypes.shape({}),
+  // thumbLeftDate: PropTypes.string.isRequired,
+  // thumbRightDate: PropTypes.string.isRequired,
 };
 
 const CompareViewHOC = (props) => {
   const filteredActiveCollection = useRecoilValue(filteredActiveCollectionState);
+  const activeCategories = useRecoilValue(activeCategoriesState);
+  const activeProviders = useRecoilValue(activeProvidersState);
+  // const timeFilters = useRecoilValue(timeFiltersState);
+  // const { dates, thumbLeftDate, thumbRightDate } = timeFilters;
 
   return (
     <CompareView
       {...props} // eslint-disable-line react/jsx-props-no-spreading
       filteredActiveCollection={filteredActiveCollection}
+      activeCategories={activeCategories}
+      activeProviders={activeProviders}
+      // dates={dates}
+      // thumbLeftDate={thumbLeftDate}
+      // thumbRightDate={thumbRightDate}
     />
   );
 };

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useRecoilValue } from 'recoil';
 
 import './CatalogView.css';
@@ -32,87 +31,59 @@ const NoResultsDisplay = React.memo(({ filteredRecordCount, activeCategories, ac
   );
 });
 
-class CompareView extends React.PureComponent {
-  state = {
-    firstTileColNum: 0,
-    numVisibleCols: 0,
-  }
-
-  renderTileColumns() {
-    const { filteredActiveCollection } = this.props;
-    const cols = Object.entries(filteredActiveCollection)
-      .sort(([categoryLabel1], [categoryLabel2]) => ((categoryLabel1 < categoryLabel2) ? -1 : 1))
-      .reduce((acc, [categoryLabel, category]) => {
-        if (category?.filteredRecordCount) {
-          acc.push(
-            <div className="tiles-view-column-container" key={categoryLabel}>
-              <div className="tiles-view-column-header">
-                {categoryLabel}
-                {/* <button className={this.buttonClass(categoryLabel)} onClick={() => this.handleSetClearButtonClick(categoryLabel)} /> */}
-              </div>
-              <div className="tiles-view-column-content">
-                { Object.entries(category.subtypes)
-                  .sort(([subtype1], [subtype2]) => ((subtype1 < subtype2) ? -1 : 1))
-                  .reduce((acc, [displayCoding, { uuids, _collectionUuids }]) => {
-                    if (uuids.length) {
-                      acc.push(<RecordSelector
-                        key={displayCoding}
-                        label={displayCoding}
-                        uuids={uuids}
-                      />);
-                    }
-                    return acc;
-                  }, []) }
-              </div>
-            </div>,
-          );
-        }
-        return acc;
-      }, []);
-
-    return cols;
-  }
-
-  render() {
-    const { activeCategories, activeProviders, filteredActiveCollection: { filteredRecordCount } } = this.props;
-    return (
-      <div className="tiles-view">
-        <div className="tiles-view-header" />
-        <div className="tiles-view-container">
-          <div className="tiles-view-container-inner">
-            { this.renderTileColumns() }
-            <NoResultsDisplay
-              filteredRecordCount={filteredRecordCount}
-              activeCategories={activeCategories}
-              activeProviders={activeProviders}
-            />
-          </div>
-        </div>
-        <SelectedCardCollection />
-      </div>
-    );
-  }
-}
-
-CompareView.propTypes = {
-  filteredActiveCollection: PropTypes.shape({}),
-  activeCategories: PropTypes.shape({}),
-  activeProviders: PropTypes.shape({}),
-};
-
-const CompareViewHOC = (props) => {
+const CompareView = () => {
   const filteredActiveCollection = useRecoilValue(filteredActiveCollectionState);
   const activeCategories = useRecoilValue(activeCategoriesState);
   const activeProviders = useRecoilValue(activeProvidersState);
 
+  const { filteredRecordCount } = filteredActiveCollection;
+
+  const columnsForCategories = Object.entries(filteredActiveCollection)
+    .sort(([categoryLabel1], [categoryLabel2]) => ((categoryLabel1 < categoryLabel2) ? -1 : 1))
+    .reduce((acc, [categoryLabel, category]) => {
+      if (category?.filteredRecordCount) {
+        acc.push(
+          <div className="tiles-view-column-container" key={categoryLabel}>
+            <div className="tiles-view-column-header">
+              {categoryLabel}
+              {/* <button className={this.buttonClass(categoryLabel)} onClick={() => this.handleSetClearButtonClick(categoryLabel)} /> */}
+            </div>
+            <div className="tiles-view-column-content">
+              { Object.entries(category.subtypes)
+                .sort(([subtype1], [subtype2]) => ((subtype1 < subtype2) ? -1 : 1))
+                .reduce((acc, [displayCoding, { uuids, _collectionUuids }]) => {
+                  if (uuids.length) {
+                    acc.push(<RecordSelector
+                      key={displayCoding}
+                      label={displayCoding}
+                      uuids={uuids}
+                    />);
+                  }
+                  return acc;
+                }, []) }
+            </div>
+          </div>,
+        );
+      }
+      return acc;
+    }, []);
+
   return (
-    <CompareView
-      {...props} // eslint-disable-line react/jsx-props-no-spreading
-      filteredActiveCollection={filteredActiveCollection}
-      activeCategories={activeCategories}
-      activeProviders={activeProviders}
-    />
+    <div className="tiles-view">
+      <div className="tiles-view-header" />
+      <div className="tiles-view-container">
+        <div className="tiles-view-container-inner">
+          { columnsForCategories }
+          <NoResultsDisplay
+            filteredRecordCount={filteredRecordCount}
+            activeCategories={activeCategories}
+            activeProviders={activeProviders}
+          />
+        </div>
+      </div>
+      <SelectedCardCollection />
+    </div>
   );
 };
 
-export default CompareViewHOC;
+export default CompareView;

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -10,23 +10,6 @@ import {
 } from '../../recoil';
 
 class CompareView extends React.PureComponent {
-  static propTypes = {
-    filteredActiveCollection: PropTypes.shape({}),
-    // resources: PropTypes.shape({
-    //   patient: PropTypes.shape({}),
-    //   providers: PropTypes.arrayOf(PropTypes.string),
-    //   legacy: PropTypes.instanceOf(FhirTransform),
-    // }),
-    // totalResCount: PropTypes.number,
-    // categories: PropTypes.arrayOf(PropTypes.string).isRequired,
-    // providers: PropTypes.arrayOf(PropTypes.string).isRequired,
-    catsEnabled: PropTypes.object.isRequired,
-    provsEnabled: PropTypes.object.isRequired,
-    thumbLeftDate: PropTypes.string.isRequired,
-    thumbRightDate: PropTypes.string.isRequired,
-    // context, nextPrevFn added in StandardFilters
-  }
-
   state = {
     firstTileColNum: 0,
     // leftColNavEnabled: true,
@@ -37,19 +20,6 @@ class CompareView extends React.PureComponent {
     // topBound: 0,
     // onlyMultisource: false,
   }
-
-  // onResize = () => {
-  //   this.setState({ numVisibleCols: this.numVisibleCols() });
-  // }
-  // buttonClass(catName) {
-  //   const selectedTilesForCat = this.state.selectedTiles[this.hyphenate(catName)];
-  //   const selectedCount = selectedTilesForCat ? Object.keys(selectedTilesForCat).length : 0;
-  //   const tilesForCatCount = this.state.uniqueStruct[catName].length;
-  //
-  //   if (selectedCount === 0) return 'tiles-view-column-header-button-none';
-  //   if (selectedCount < tilesForCatCount) return 'tiles-view-column-header-button-partial';
-  //   return 'tiles-view-column-header-button-all';
-  // }
 
   noneEnabled(obj) {
     for (const propName of Object.keys(obj)) {
@@ -161,6 +131,23 @@ class CompareView extends React.PureComponent {
     );
   }
 }
+
+CompareView.propTypes = {
+  filteredActiveCollection: PropTypes.shape({}),
+  // resources: PropTypes.shape({
+  //   patient: PropTypes.shape({}),
+  //   providers: PropTypes.arrayOf(PropTypes.string),
+  //   legacy: PropTypes.instanceOf(FhirTransform),
+  // }),
+  // totalResCount: PropTypes.number,
+  // categories: PropTypes.arrayOf(PropTypes.string).isRequired,
+  // providers: PropTypes.arrayOf(PropTypes.string).isRequired,
+  catsEnabled: PropTypes.object.isRequired,
+  provsEnabled: PropTypes.object.isRequired,
+  thumbLeftDate: PropTypes.string.isRequired,
+  thumbRightDate: PropTypes.string.isRequired,
+  // context, nextPrevFn added in StandardFilters
+};
 
 const CompareViewHOC = (props) => {
   const filteredActiveCollection = useRecoilValue(filteredActiveCollectionState);

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -41,15 +41,6 @@ class CompareView extends React.PureComponent {
   // onResize = () => {
   //   this.setState({ numVisibleCols: this.numVisibleCols() });
   // }
-
-  handleSetClearButtonClick = (catName) => {
-    console.error(`TODO: handleSetClearButtonClick(${catName}): re-impliment via recoil`); // eslint-disable-line no-console
-  }
-
-  hyphenate(name) {
-    return name.toLowerCase().replace(/ /g, '-');
-  }
-
   // buttonClass(catName) {
   //   const selectedTilesForCat = this.state.selectedTiles[this.hyphenate(catName)];
   //   const selectedCount = selectedTilesForCat ? Object.keys(selectedTilesForCat).length : 0;
@@ -85,7 +76,7 @@ class CompareView extends React.PureComponent {
       .reduce((acc, [categoryLabel, category]) => {
         if (category?.filteredRecordCount) {
           acc.push(
-            <div className={`${this.hyphenate(categoryLabel)} tiles-view-column-container`} key={categoryLabel}>
+            <div className="tiles-view-column-container" key={categoryLabel}>
               <div className="tiles-view-column-header">
                 {categoryLabel}
                 {/* <button className={this.buttonClass(categoryLabel)} onClick={() => this.handleSetClearButtonClick(categoryLabel)} /> */}

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -9,19 +9,12 @@ import {
   activeCategoriesState,
   activeProvidersState,
   filteredActiveCollectionState,
-  // timeFiltersState,
 } from '../../recoil';
 
 class CompareView extends React.PureComponent {
   state = {
     firstTileColNum: 0,
-    // leftColNavEnabled: true,
-    // rightColNavEnabled: true,
-    // uniqueStruct: {},
     numVisibleCols: 0,
-    // lastTileSelected: null,
-    // topBound: 0,
-    // onlyMultisource: false,
   }
 
   noneEnabled(obj) {
@@ -86,12 +79,6 @@ class CompareView extends React.PureComponent {
   }
 
   onNavClick = (_dir) => {
-    // if (dir === 'left') {
-    //   this.setState({ firstTileColNum: Math.max(0, this.state.firstTileColNum - 1) });
-    // } else {
-    //   const maxFirstTileColNum = Object.keys(this.state.uniqueStruct).length - Math.trunc(this.state.numVisibleCols);
-    //   this.setState({ firstTileColNum: Math.min(maxFirstTileColNum, this.state.firstTileColNum + 1) });
-    // }
   }
 
   render() {
@@ -109,7 +96,6 @@ class CompareView extends React.PureComponent {
             <div className="tiles-view-nav-left">
               <button
                 className={this.state.firstTileColNum > 0 ? 'tiles-view-nav-left-button-on' : 'tiles-view-nav-left-button-off'}
-                onClick={() => this.onNavClick('left')}
               />
             </div>
           ) }
@@ -135,16 +121,12 @@ CompareView.propTypes = {
   filteredActiveCollection: PropTypes.shape({}),
   activeCategories: PropTypes.shape({}),
   activeProviders: PropTypes.shape({}),
-  // thumbLeftDate: PropTypes.string.isRequired,
-  // thumbRightDate: PropTypes.string.isRequired,
 };
 
 const CompareViewHOC = (props) => {
   const filteredActiveCollection = useRecoilValue(filteredActiveCollectionState);
   const activeCategories = useRecoilValue(activeCategoriesState);
   const activeProviders = useRecoilValue(activeProvidersState);
-  // const timeFilters = useRecoilValue(timeFiltersState);
-  // const { dates, thumbLeftDate, thumbRightDate } = timeFilters;
 
   return (
     <CompareView
@@ -152,9 +134,6 @@ const CompareViewHOC = (props) => {
       filteredActiveCollection={filteredActiveCollection}
       activeCategories={activeCategories}
       activeProviders={activeProviders}
-      // dates={dates}
-      // thumbLeftDate={thumbLeftDate}
-      // thumbRightDate={thumbRightDate}
     />
   );
 };

--- a/src/components/CatalogView/index.js
+++ b/src/components/CatalogView/index.js
@@ -33,7 +33,6 @@ class CompareView extends React.PureComponent {
     // rightColNavEnabled: true,
     uniqueStruct: {},
     numVisibleCols: 0,
-    selectedTiles: {},
     // lastTileSelected: null,
     // topBound: 0,
     // onlyMultisource: false,
@@ -76,7 +75,6 @@ class CompareView extends React.PureComponent {
     } if (this.noneEnabled(this.props.provsEnabled)) {
       return 'No Provider is selected';
     }
-    console.error('this.props.noResultDisplay: ', this.props.noResultDisplay);
     return this.props.noResultDisplay ? this.props.noResultDisplay : 'No data found for the selected Records, Providers, and Time period';
   }
 
@@ -137,14 +135,11 @@ class CompareView extends React.PureComponent {
   }
 
   render() {
-    const { filteredActiveCollection, catsEnabled, provsEnabled } = this.props;
+    const { filteredActiveCollection } = this.props;
 
-    // const enablededCategoryCount = Object.values(catsEnabled).reduce((acc, enabled) => (enabled ? (acc + 1) : acc), 0);
     const enablededCategoryCount = Object.values(filteredActiveCollection).reduce((acc, category) => (category.totalCount ? (acc + 1) : acc), 0);
 
     const maxFirstTileColNum = enablededCategoryCount - Math.trunc(this.state.numVisibleCols);
-
-    const tileSelected = Object.keys(this.state.selectedTiles).length > 0;
 
     return (
       <div className="tiles-view">

--- a/src/components/CompareView/index.js
+++ b/src/components/CompareView/index.js
@@ -44,8 +44,8 @@ export default class CompareView extends React.PureComponent {
     providers: PropTypes.arrayOf(PropTypes.string).isRequired,
     catsEnabled: PropTypes.object.isRequired,
     provsEnabled: PropTypes.object.isRequired,
-    thumbLeftDate: PropTypes.string.isRequired,
-    thumbRightDate: PropTypes.string.isRequired,
+    dateRangeStart: PropTypes.string.isRequired,
+    dateRangeEnd: PropTypes.string.isRequired,
     // context, nextPrevFn added in StandardFilters
   }
 
@@ -206,7 +206,7 @@ export default class CompareView extends React.PureComponent {
       : legacy.pathItem(`[*category=${cat}][*provider=${prov}]`);
     for (const res of resources) {
       if (this.noCompareCategories.includes(res.category)
-        || !inDateRange(res.itemDate, this.props.thumbLeftDate, this.props.thumbRightDate)) {
+        || !inDateRange(res.itemDate, this.props.dateRangeStart, this.props.dateRangeEnd)) {
         continue; // Ignore this resource
       }
 
@@ -702,8 +702,8 @@ export default class CompareView extends React.PureComponent {
           initialPositionYFn={this.initialPositionY.bind(this)}
           onResizeFn={this.onContentPanelResize.bind(this)}
           nextPrevFn={this.props.nextPrevFn}
-          thumbLeftDate={this.props.thumbLeftDate}
-          thumbRightDate={this.props.thumbRightDate}
+          dateRangeStart={this.props.dateRangeStart}
+          dateRangeEnd={this.props.dateRangeEnd}
           resources={this.selectedUniqueItemResources()}
           patient={this.props.resources.patient}
           providers={this.props.resources.providers}

--- a/src/components/ContentPanel/ContentRight.js
+++ b/src/components/ContentPanel/ContentRight.js
@@ -74,8 +74,8 @@ class ContentPanel extends React.PureComponent {
     catsEnabled: PropTypes.object.isRequired,
     provsEnabled: PropTypes.object.isRequired,
     nextPrevFn: PropTypes.func, // added dynamically by StandardFilters
-    thumbLeftDate: PropTypes.string.isRequired,
-    thumbRightDate: PropTypes.string.isRequired,
+    dateRangeStart: PropTypes.string.isRequired,
+    dateRangeEnd: PropTypes.string.isRequired,
     viewName: PropTypes.string.isRequired,
     viewIconClass: PropTypes.string.isRequired,
     // ------ note that resources are not no directly receiving recoil state "resources":
@@ -315,14 +315,14 @@ class ContentPanel extends React.PureComponent {
       && res.category !== 'Patient'
       && this.catEnabled(res.category)
       && this.provEnabled(res.provider)
-      && inDateRange(res.itemDate, this.props.thumbLeftDate,
-        this.props.thumbRightDate)
+      && inDateRange(res.itemDate, this.props.dateRangeStart,
+        this.props.dateRangeEnd)
       && (!this.state.onlyAnnotated || (res.data.discoveryAnnotation
         && res.data.discoveryAnnotation.annotationHistory))) : this.props.resources.transformed.filter((res) => res.category !== 'Patient'
       && this.catEnabled(res.category)
       && this.provEnabled(res.provider)
-      && inDateRange(res.itemDate, this.props.thumbLeftDate,
-        this.props.thumbRightDate)
+      && inDateRange(res.itemDate, this.props.dateRangeStart,
+        this.props.dateRangeEnd)
       && (!this.state.onlyAnnotated || (res.data.discoveryAnnotation
         && res.data.discoveryAnnotation.annotationHistory)));
 

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -165,7 +165,6 @@ class DiscoveryApp extends React.PureComponent {
                       </Route>
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/catalog`}>
                         <CatalogView
-                          resources={this.props.resources}
                           totalResCount={totalResCount}
                           dates={dates}
                           categories={categories}
@@ -178,6 +177,7 @@ class DiscoveryApp extends React.PureComponent {
                       </Route>
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/compare`}>
                         <CompareView
+                          resources={this.props.resources}
                           totalResCount={totalResCount}
                           dates={dates}
                           categories={categories}

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -46,13 +46,7 @@ class DiscoveryApp extends React.PureComponent {
     // isLoading: false,
     // fetchError: null, // Possible axios error object
     // lastEvent: null,
-    // thumbLeftDate: null,
-    // thumbRightDate: null,
     dotClickDate: null, // dot click from ContentPanel
-
-    // catsEnabled: null,
-    // provsEnabled: null,
-    // providers: [],
 
     // Shared Global Context
     updateGlobalContext: (updates) => this.setState(updates),
@@ -118,7 +112,7 @@ class DiscoveryApp extends React.PureComponent {
       resources, activeCategories, activeProviders, timeFilters,
     } = this.props;
 
-    const { dates, thumbLeftDate, thumbRightDate } = timeFilters;
+    const { dates, dateRangeStart, dateRangeEnd } = timeFilters;
 
     const {
       totalResCount, providers, categories,
@@ -175,8 +169,8 @@ class DiscoveryApp extends React.PureComponent {
                           providers={providers}
                           catsEnabled={activeCategories}
                           provsEnabled={activeProviders}
-                          thumbLeftDate={thumbLeftDate}
-                          thumbRightDate={thumbRightDate}
+                          dateRangeStart={dateRangeStart}
+                          dateRangeEnd={dateRangeEnd}
                         />
                       </Route>
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/timeline`}>
@@ -189,8 +183,8 @@ class DiscoveryApp extends React.PureComponent {
                           topBoundFn={this.calcContentPanelTopBound}
                           bottomBoundFn={this.calcContentPanelBottomBound}
                           // context, nextPrevFn added in StandardFilters
-                          thumbLeftDate={thumbLeftDate}
-                          thumbRightDate={thumbRightDate}
+                          dateRangeStart={dateRangeStart}
+                          dateRangeEnd={dateRangeEnd}
                           resources={legacyResources}
                           providers={providers}
                           totalResCount={totalResCount}

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -178,7 +178,6 @@ class DiscoveryApp extends React.PureComponent {
                       </Route>
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/compare`}>
                         <CompareView
-                          resources={this.props.resources}
                           totalResCount={totalResCount}
                           dates={dates}
                           categories={categories}

--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -164,16 +164,7 @@ class DiscoveryApp extends React.PureComponent {
                         />
                       </Route>
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/catalog`}>
-                        <CatalogView
-                          totalResCount={totalResCount}
-                          dates={dates}
-                          categories={categories}
-                          providers={providers}
-                          catsEnabled={activeCategories}
-                          provsEnabled={activeProviders}
-                          thumbLeftDate={thumbLeftDate}
-                          thumbRightDate={thumbRightDate}
-                        />
+                        <CatalogView />
                       </Route>
                       <Route path={`${PATIENT_MODE_SEGMENT}/:participantId/compare`}>
                         <CompareView

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -221,8 +221,8 @@ class StandardFilters extends React.PureComponent {
   // Record thumb positions as returned from StandardFilters
   setDateRange = (minDate, maxDate) => {
     this.props.updateTimeFilters({
-      dateRangeStart: minDate,
-      dateRangeEnd: maxDate,
+      dateRangeStart: minDate.substring(0, 10),
+      dateRangeEnd: maxDate.substring(0, 10),
     });
   }
 

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -221,8 +221,8 @@ class StandardFilters extends React.PureComponent {
   // Record thumb positions as returned from StandardFilters
   setDateRange = (minDate, maxDate) => {
     this.props.updateTimeFilters({
-      thumbLeftDate: minDate,
-      thumbRightDate: maxDate,
+      dateRangeStart: minDate,
+      dateRangeEnd: maxDate,
     });
   }
 

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -181,6 +181,12 @@ export const activeCollectionState = selector({
   },
 });
 
+// derived from util.js inDateRange, but simplified: TODO: use date-fns and tz-aware Date math?
+const isInDateRange = (date, dateRangeStart, dateRangeEnd) => {
+  const dateStr = date.substring(0, 10);
+  return dateStr >= dateRangeStart && dateStr <= dateRangeEnd;
+};
+
 // shape has diverged from groupedRecordIdsBySubtypeState:
 export const filteredActiveCollectionState = selector({
   key: 'filteredActiveCollectionState',
@@ -189,31 +195,35 @@ export const filteredActiveCollectionState = selector({
     const activeCollection = get(activeCollectionState);
     const activeCategories = get(activeCategoriesState);
     const activeProviders = get(activeProvidersState);
+    const { dateRangeStart, dateRangeEnd } = get(timeFiltersState);
     const { records } = get(resourcesState);
     const lastUuidsClicked = get(lastRecordsClickedState);
-    let totalFilteredRecordCount = 0; // total count of all uuids in call categories, after applying category and provider (and todo: timeline) filters
-    let totalFilteredCollectionCount = 0; // count of uuids in totalFilteredRecordCount, that are also in the current collection
+    let totalFilteredRecordCount = 0; // total count of all uuids in all categories, after applying category, provider, and timeline filters
+    let totalFilteredCollectionCount = 0; // all uuids in ^totalFilteredRecordCount, that are also in the current collection
     const { uuids: uuidsInCollection } = activeCollection;
     const filteredCategories = Object.entries(groupedRecordIdsBySubtype)
       .filter(([catLabel]) => (activeCategories[catLabel]))
       .reduce((accCats, [catLabel, category]) => {
         accCats[catLabel] = Object.entries(category.subtypes).reduce((accCategory, [subtypeLabel, uuids]) => {
-          const uuidsForEnabledProviders = uuids.filter((uuid) => activeProviders[records[uuid].provider]);
-          const activeUuids = uuidsForEnabledProviders.filter((uuid) => uuidsInCollection[uuid]);
+          const uuidsFiltered = uuids.filter((uuid) => {
+            const record = records[uuid];
+            return activeProviders[record.provider] && isInDateRange(record.itemDate, dateRangeStart, dateRangeEnd);
+          });
+          const activeUuids = uuidsFiltered.filter((uuid) => uuidsInCollection[uuid]);
           const hasLastAdded = activeUuids.reduce((acc, uuid) => lastUuidsClicked[uuid] || acc, false);
-          accCategory.filteredRecordCount += uuidsForEnabledProviders.length;
+          accCategory.filteredRecordCount += uuidsFiltered.length;
           accCategory.filteredCollectionCount += activeUuids.length;
           accCategory.subtypes[subtypeLabel] = {
             hasLastAdded,
-            uuids: uuidsForEnabledProviders, // not all subtype uuids -- just uuids for sub filtered by category and provider
-            collectionUuids: activeUuids,
+            uuids: uuidsFiltered, // not all subtype uuids -- just uuids for subtype, filtered by category, provider, and timeline filters
+            collectionUuids: activeUuids, // count of uuids in ^uuidsFiltered, that are also in the current collection
           };
-          totalFilteredRecordCount += uuidsForEnabledProviders.length;
+          totalFilteredRecordCount += uuidsFiltered.length;
           totalFilteredCollectionCount += activeUuids.length;
           return accCategory;
         }, {
-          filteredRecordCount: 0, // count of all uuids in category, after applying category and provider (and todo: timeline) filters
-          filteredCollectionCount: 0, // count of uuids in category filteredRecordCount, that are also in the current collection
+          filteredRecordCount: 0, // count of all uuids in category, after applying category, provider, and timeline filters
+          filteredCollectionCount: 0, // count of uuids in ^filteredRecordCount, that are also in the current collection
           totalCount: category.totalCount,
           subtypes: {},
         });

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -25,8 +25,15 @@ const timeFilters = atom({
   key: 'timeFilters',
   default: {
     dates: null,
-    thumbLeftDate: null,
-    thumbRightDate: null,
+    // dates: {
+    //   allDates: null,
+    //   minDate: null,
+    //   startDate: null,
+    //   maxDate: null,
+    //   endDate: null,
+    // },
+    dateRangeStart: null,
+    dateRangeEnd: null,
   },
 });
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -286,8 +286,8 @@ export const computeFilterState = (legacyResources) => {
 
   return {
     dates,
-    thumbLeftDate: minDate,
-    thumbRightDate: maxDate,
+    dateRangeStart: minDate,
+    dateRangeEnd: maxDate,
   };
 };
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -286,8 +286,8 @@ export const computeFilterState = (legacyResources) => {
 
   return {
     dates,
-    dateRangeStart: minDate,
-    dateRangeEnd: maxDate,
+    dateRangeStart: minDate.substring(0, 10),
+    dateRangeEnd: maxDate.substring(0, 10),
   };
 };
 


### PR DESCRIPTION
This PR makes the CatalogView record-picker respond to category, provider, and timeline filters from recoil state:

https://user-images.githubusercontent.com/3383704/107671747-2ba8a700-6c62-11eb-971f-a36a987b8ae2.mov


----------------------------------------------------
This PR preserves the "no results" messaging in `origin/master`:
https://user-images.githubusercontent.com/3383704/107670631-eb94f480-6c60-11eb-9aff-085c71a801e3.mov


----------------------------------------------------
Note: the left/right "column browser" was dropped, due to its complexity:
![image](https://user-images.githubusercontent.com/3383704/107670974-4cbcc800-6c61-11eb-9268-aef8ef4ee125.png)
(but the "Clear" button is removed, as requested)
...If it's still a requirement, the "column browser" should be re-implemented as a dedicated component via a separate PR.


----------------------------------------------------
also dropped:
The toggle-boxes to the right of each column header:
![image](https://user-images.githubusercontent.com/3383704/107671253-a1604300-6c61-11eb-801b-ff7127ba4e50.png)
