### PR TITLE
Use primary theme color in summary view

### DIFF
--- a/src/svg/summary-icon-catalog.svg
+++ b/src/svg/summary-icon-catalog.svg
@@ -4,21 +4,21 @@
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
-	.st1{fill:#8A98B5;}
-	.st2{fill:#8798B8;}
+	.st1{fill:#4197C6;}
+	.st2{fill:#4197C6;}
 	.st3{fill:#DBE3F5;}
 	.st4{fill:none;stroke:#DBE3F5;stroke-width:1.198;stroke-linecap:round;stroke-miterlimit:10;}
 	.st5{fill:none;stroke:#DBE3F5;stroke-width:0.898;stroke-linecap:round;stroke-miterlimit:10;}
 	.st6{fill:none;stroke:#DBE3F5;stroke-width:2.396;stroke-linecap:round;stroke-miterlimit:10;}
-	.st7{fill:none;stroke:#8798B8;stroke-width:0.898;stroke-linecap:round;stroke-miterlimit:10;}
-	.st8{fill:none;stroke:#8798B8;stroke-width:1.198;stroke-miterlimit:10;}
+	.st7{fill:none;stroke:#4197C6;stroke-width:0.898;stroke-linecap:round;stroke-miterlimit:10;}
+	.st8{fill:none;stroke:#4197C6;stroke-width:1.198;stroke-miterlimit:10;}
 	.st9{fill:none;stroke:#DBE3F5;stroke-width:1.198;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st10{fill:none;stroke:#DBE3F5;stroke-width:1.198;stroke-miterlimit:10;}
-	.st11{fill:none;stroke:#8798B8;stroke-width:1.797;stroke-linejoin:round;stroke-miterlimit:10;}
-	.st12{fill:none;stroke:#8798B8;stroke-width:1.198;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st11{fill:none;stroke:#4197C6;stroke-width:1.797;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st12{fill:none;stroke:#4197C6;stroke-width:1.198;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st13{fill:none;stroke:#DBE3F5;stroke-width:1.198;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
-	
-		.st14{clip-path:url(#SVGID_2_);fill:none;stroke:#8798B8;stroke-width:1.198;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+
+		.st14{clip-path:url(#SVGID_2_);fill:none;stroke:#4197C6;stroke-width:1.198;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
 <g id="Layer_1">
 	<rect x="50" class="st0" width="50" height="100"/>

--- a/src/svg/summary-icon-compare.svg
+++ b/src/svg/summary-icon-compare.svg
@@ -4,10 +4,10 @@
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
-	.st1{fill:#8A98B5;}
-	.st2{fill:#8798B8;}
+	.st1{fill:#4197C6;}
+	.st2{fill:#4197C6;}
 	.st3{clip-path:url(#SVGID_2_);fill:#DBE3F5;}
-	.st4{fill:none;stroke:#8798B8;stroke-width:2.279;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st4{fill:none;stroke:#4197C6;stroke-width:2.279;stroke-linejoin:round;stroke-miterlimit:10;}
 	.st5{clip-path:url(#SVGID_4_);fill:#DBE3F5;}
 	.st6{clip-path:url(#SVGID_4_);fill:none;stroke:#DBE3F5;stroke-width:1.436;stroke-miterlimit:10;}
 	.st7{fill:none;stroke:#DBE3F5;stroke-miterlimit:10;}

--- a/src/svg/summary-icon-timeline.svg
+++ b/src/svg/summary-icon-timeline.svg
@@ -4,8 +4,8 @@
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
-	.st1{fill:#8A98B5;}
-	.st2{fill:#8798B8;}
+	.st1{fill:#4197C6;}
+	.st2{fill:#4197C6;}
 	.st3{clip-path:url(#SVGID_2_);fill:none;stroke:#DBE3F5;stroke-width:1.5;stroke-miterlimit:10;}
 	.st4{clip-path:url(#SVGID_2_);fill:#DBE3F5;}
 	.st5{clip-path:url(#SVGID_2_);}


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/110988/107935802-2610d100-6f82-11eb-9aab-55c7b6167c92.png)

After:

![image](https://user-images.githubusercontent.com/110988/107935812-29a45800-6f82-11eb-8394-5f7cc6e47ecb.png)

Some JS+SVG cleverness is likely possible to have it be automatic - and but the deadline doesn't permit that at the moment.