### PR TITLE
Decouple timeline "range params" from timeline "filter" state

### DIFF
--- a/src/components/DiscoveryApp/index.js
+++ b/src/components/DiscoveryApp/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { get } from 'axios';
 
 import './DiscoveryApp.css';
@@ -14,11 +14,9 @@ import CatalogView from '../CatalogView';
 import Collections from '../Collections';
 import { PATIENT_MODE_SEGMENT } from '../../index';
 import {
-  normalizeResourcesAndInjectPartipantId, generateRecordsDictionary, generateLegacyResources, computeFilterState, extractProviders, extractCategories,
+  normalizeResourcesAndInjectPartipantId, generateRecordsDictionary, generateLegacyResources, extractProviders, extractCategories,
 } from '../../utils/api';
-import {
-  resourcesState, timeFiltersState,
-} from '../../recoil';
+import { resourcesState } from '../../recoil';
 
 import CategoryFilter from '../filters/CategoryFilter';
 import ProviderFilter from '../filters/ProviderFilter';
@@ -101,7 +99,6 @@ class DiscoveryApp extends React.PureComponent {
 // if using React.memo, there's a proptype warning for Route:
 const DiscoveryAppHOC = (props) => {
   const [resources, setResources] = useRecoilState(resourcesState);
-  const updateTimeFilters = useSetRecoilState(timeFiltersState);
 
   useEffect(() => {
     function fetchData() {
@@ -138,11 +135,6 @@ const DiscoveryAppHOC = (props) => {
           providers,
           categories,
           legacy,
-        });
-
-        // TODO: migrate this call to recoil.js so it is automatically derived from resources.legacy, using DefaultValue api ?
-        updateTimeFilters({
-          ...computeFilterState(legacy),
         });
       }).catch((error) => {
         setResources({

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -510,10 +510,10 @@ class StandardFilters extends React.PureComponent {
 
     return (
       <TimeWidget
-        minDate={timelineRangeParams ? timelineRangeParams.minDate : ''}
-        maxDate={timelineRangeParams ? timelineRangeParams.maxDate : ''}
-        startDate={timelineRangeParams ? timelineRangeParams.startDate : ''}
-        endDate={timelineRangeParams ? timelineRangeParams.endDate : ''}
+        minDate={timelineRangeParams.minDate ?? ''}
+        maxDate={timelineRangeParams.maxDate ?? ''}
+        startDate={timelineRangeParams.startDate ?? ''}
+        endDate={timelineRangeParams.endDate ?? ''}
         dotContext={this.props.dotClickContext}
         thumbLeft={this.state.minActivePos}
         thumbRight={this.state.maxActivePos}

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -541,6 +541,10 @@ const StandardFiltersHOC = React.memo((props) => {
   const activeCategories = useRecoilValue(activeCategoriesState);
   const activeProviders = useRecoilValue(activeProvidersState);
 
+  if (!timelineRangeParams.allDates) {
+    return null;
+  }
+
   return (
     <StandardFilters
       {...props} // eslint-disable-line react/jsx-props-no-spreading

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -3,6 +3,7 @@ import {
   atom,
   useRecoilState,
   useRecoilValue,
+  useSetRecoilState,
 } from 'recoil';
 import PropTypes from 'prop-types';
 
@@ -16,7 +17,7 @@ import Unimplemented from '../Unimplemented';
 
 import { SUBROUTES } from '../../constants';
 import {
-  activeCategoriesState, activeProvidersState, resourcesState, timeFiltersState,
+  activeCategoriesState, activeProvidersState, resourcesState, timelineRangeParamsState, timeFiltersState,
 } from '../../recoil';
 
 const ALLOW_DOT_CLICK = true;
@@ -25,7 +26,7 @@ class StandardFilters extends React.PureComponent {
   static propTypes = {
     activeView: PropTypes.oneOf(SUBROUTES),
     resources: PropTypes.instanceOf(FhirTransform),
-    dates: PropTypes.shape({
+    timelineRangeParams: PropTypes.shape({
       allDates: PropTypes.arrayOf(PropTypes.shape({
         position: PropTypes.number.isRequired,
         date: PropTypes.string.isRequired,
@@ -61,22 +62,23 @@ class StandardFilters extends React.PureComponent {
     window.addEventListener('resize', this.onResize);
     // window.addEventListener('keydown', this.onEvent);
     this.updateSvgWidth();
-    if (this.props.dates?.allDates && ALLOW_DOT_CLICK) {
-      const data = this.fetchDataForDot('TimeWidget', 'Full', this.props.dates.maxDate);
+    const { timelineRangeParams } = this.props;
+    if (timelineRangeParams?.allDates && ALLOW_DOT_CLICK) {
+      const data = this.fetchDataForDot('TimeWidget', 'Full', timelineRangeParams.maxDate);
       // console.info('fetchDataForDot, data: ', JSON.stringify(data, null, '  '));
       this.props.setDotClickContext({
         parent: 'TimeWidget',
         rowName: 'Full',
         dotType: 'active',
-        minDate: this.props.dates.minDate,
-        maxDate: this.props.dates.maxDate,
-        startDate: this.props.dates.startDate,
-        endDate: this.props.dates.endDate,
+        minDate: timelineRangeParams.minDate,
+        maxDate: timelineRangeParams.maxDate,
+        startDate: timelineRangeParams.startDate,
+        endDate: timelineRangeParams.endDate,
 
-        allDates: this.props.dates.allDates,
-        date: this.props.dates.maxDate,
+        allDates: timelineRangeParams.allDates,
+        date: timelineRangeParams.maxDate,
         data,
-        position: this.props.dates.allDates[this.props.dates.allDates.length - 1].position,
+        position: timelineRangeParams.allDates[timelineRangeParams.allDates.length - 1].position,
       });
     }
   }
@@ -116,15 +118,16 @@ class StandardFilters extends React.PureComponent {
       //      this.setState({ dotClickContext: newContext });
       //   }
     } else if (ALLOW_DOT_CLICK && prevState.dotClickDate !== this.state.dotClickDate) {
-      // Set dotClickContext from dot clicked in ContentPanel (via this.state.dotClickDate)
-      const theDate = this.props.dates.allDates.find((elt) => new Date(elt.date).getTime() === new Date(this.state.dotClickDate).getTime());
+      // Set dotClickContext from dot clicked in ContentPanel (via this.state.dotClickDate)'
+      const { timelineRangeParams } = this.props;
+      const theDate = timelineRangeParams.allDates.find((elt) => new Date(elt.date).getTime() === new Date(this.state.dotClickDate).getTime());
       this.props.setDotClickContext({
         parent: 'TimeWidget',
         rowName: 'Full',
         dotType: 'active',
-        minDate: this.props.dates.minDate,
-        maxDate: this.props.dates.maxDate,
-        allDates: this.props.dates.allDates,
+        minDate: timelineRangeParams.minDate,
+        maxDate: timelineRangeParams.maxDate,
+        allDates: timelineRangeParams.allDates,
         date: theDate.date,
         data: this.fetchDataForDot('TimeWidget', 'Full', theDate.date),
         position: theDate.position,
@@ -188,9 +191,10 @@ class StandardFilters extends React.PureComponent {
 
   // TODO: Move to util.js?
   posToDate(pos) {
-    if (this.props.dates) {
-      const min = new Date(this.props.dates.startDate ? this.props.dates.startDate : 0).getTime();
-      const max = new Date(this.props.dates.endDate ? this.props.dates.endDate : 0).getTime();
+    const { timelineRangeParams } = this.props;
+    if (timelineRangeParams) {
+      const min = new Date(timelineRangeParams.startDate ? timelineRangeParams.startDate : 0).getTime();
+      const max = new Date(timelineRangeParams.endDate ? timelineRangeParams.endDate : 0).getTime();
       const target = min + (max - min) * pos;
       return new Date(target).toISOString();
     }
@@ -199,8 +203,9 @@ class StandardFilters extends React.PureComponent {
 
   // TODO: Move to util.js?
   dateToPos(dateStr) {
-    const min = new Date(this.props.dates.startDate ? this.props.dates.startDate : 0).getTime();
-    const max = new Date(this.props.dates.endDate ? this.props.dates.endDate : 0).getTime();
+    const { timelineRangeParams } = this.props;
+    const min = new Date(timelineRangeParams.startDate ? timelineRangeParams.startDate : 0).getTime();
+    const max = new Date(timelineRangeParams.endDate ? timelineRangeParams.endDate : 0).getTime();
     const target = new Date(dateStr).getTime();
     return (target - min) / (max - min);
   }
@@ -290,13 +295,14 @@ class StandardFilters extends React.PureComponent {
     console.info('obsolete onDotClick -- context, date, dotType: ', context, date, dotType); // eslint-disable-line no-console
     try {
       if (ALLOW_DOT_CLICK) {
+        const { timelineRangeParams } = this.props;
         const rowDates = this.fetchDotPositions(context.parent, context.rowName, true, true);
         const { position } = rowDates.find((elt) => elt.date === date);
 
         context.dotType = this.updateDotType(dotType, position, false);
         context.minDate = rowDates[0].date;
         context.maxDate = rowDates[rowDates.length - 1].date;
-        context.allDates = this.props.dates.allDates;
+        context.allDates = timelineRangeParams.allDates;
         context.date = date;
         context.position = position;
         context.data = this.fetchDataForDot(context.parent, context.rowName, context.date);
@@ -331,10 +337,11 @@ class StandardFilters extends React.PureComponent {
   fetchDotPositions = this.fetchDotPositions.bind(this);
 
   fetchDotPositions(parent, rowName, isEnabled, fetchAll) {
-    if (!this.props.resources || !this.props.dates || this.props.dates.allDates.length === 0) {
+    const { timelineRangeParams } = this.props;
+    if (!this.props.resources || !timelineRangeParams || timelineRangeParams.allDates.length === 0) {
       return [];
     }
-    const { startDate, endDate, allDates } = this.props.dates;
+    const { startDate, endDate, allDates } = timelineRangeParams;
     const { searchRefs } = this.state;
     const viewAccentRefs = this.state.viewAccentDates.reduce((result, date) => {
       result.push({
@@ -498,15 +505,15 @@ class StandardFilters extends React.PureComponent {
   // TODO: handle noDots for LongitudinalView???
   render() {
     //      console.log('SF render: ' + (this.props.dotClickContext ? this.props.dotClickContext.date : this.props.dotClickContext));
-    const { dates } = this.props;
+    const { timelineRangeParams } = this.props;
     const dotClickFn = ALLOW_DOT_CLICK ? this.onDotClick : null;
 
     return (
       <TimeWidget
-        minDate={dates ? dates.minDate : ''}
-        maxDate={dates ? dates.maxDate : ''}
-        startDate={dates ? dates.startDate : ''}
-        endDate={dates ? dates.endDate : ''}
+        minDate={timelineRangeParams ? timelineRangeParams.minDate : ''}
+        maxDate={timelineRangeParams ? timelineRangeParams.maxDate : ''}
+        startDate={timelineRangeParams ? timelineRangeParams.startDate : ''}
+        endDate={timelineRangeParams ? timelineRangeParams.endDate : ''}
         dotContext={this.props.dotClickContext}
         thumbLeft={this.state.minActivePos}
         thumbRight={this.state.maxActivePos}
@@ -525,7 +532,8 @@ export const dotClickContextState = atom({
 });
 
 const StandardFiltersHOC = React.memo((props) => {
-  const [timeFilters, updateTimeFilters] = useRecoilState(timeFiltersState);
+  const timelineRangeParams = useRecoilValue(timelineRangeParamsState);
+  const updateTimeFilters = useSetRecoilState(timeFiltersState);
   const { legacy } = useRecoilValue(resourcesState);
 
   const [dotClickContext, setDotClickContext] = useRecoilState(dotClickContextState);
@@ -542,7 +550,7 @@ const StandardFiltersHOC = React.memo((props) => {
       activeCategories={activeCategories}
       activeProviders={activeProviders}
       resources={legacy}
-      dates={timeFilters.dates}
+      timelineRangeParams={timelineRangeParams}
     />
   );
 });

--- a/src/components/StandardFilters/index.js
+++ b/src/components/StandardFilters/index.js
@@ -61,7 +61,9 @@ class StandardFilters extends React.PureComponent {
     window.addEventListener('resize', this.onResize);
     // window.addEventListener('keydown', this.onEvent);
     this.updateSvgWidth();
-    if (this.props.dates && ALLOW_DOT_CLICK) {
+    if (this.props.dates?.allDates && ALLOW_DOT_CLICK) {
+      const data = this.fetchDataForDot('TimeWidget', 'Full', this.props.dates.maxDate);
+      // console.info('fetchDataForDot, data: ', JSON.stringify(data, null, '  '));
       this.props.setDotClickContext({
         parent: 'TimeWidget',
         rowName: 'Full',
@@ -70,9 +72,10 @@ class StandardFilters extends React.PureComponent {
         maxDate: this.props.dates.maxDate,
         startDate: this.props.dates.startDate,
         endDate: this.props.dates.endDate,
+
         allDates: this.props.dates.allDates,
         date: this.props.dates.maxDate,
-        data: this.fetchDataForDot('TimeWidget', 'Full', this.props.dates.maxDate),
+        data,
         position: this.props.dates.allDates[this.props.dates.allDates.length - 1].position,
       });
     }

--- a/src/components/SummaryView/index.js
+++ b/src/components/SummaryView/index.js
@@ -8,12 +8,12 @@ import FhirTransform from '../../FhirTransform.js';
 import { formatPatientName, formatPatientAddress } from '../../fhirUtil.js';
 import { formatDisplayDate, formatAge, titleCase } from '../../util.js';
 import Unimplemented from '../Unimplemented';
-import { resourcesState, timeFiltersState } from '../../recoil';
+import { resourcesState, timelineRangeParamsState } from '../../recoil';
 
 class SummaryView extends React.PureComponent {
   static propTypes = {
     resources: PropTypes.instanceOf(FhirTransform),
-    dates: PropTypes.shape({
+    timelineRangeParams: PropTypes.shape({
       allDates: PropTypes.arrayOf(PropTypes.shape({
         position: PropTypes.number.isRequired,
         date: PropTypes.string.isRequired,
@@ -122,7 +122,7 @@ class SummaryView extends React.PureComponent {
 
   renderLeftCol() {
     const name = formatPatientName(this.props.resources.pathItem('[category=Patient].data.name'));
-
+    const { timelineRangeParams } = this.props;
     return (
       <div className="summary-view-left-column">
         <div className="participant">
@@ -133,10 +133,10 @@ class SummaryView extends React.PureComponent {
             DATA RANGE
           </div>
           <div className="data-range-value">
-            { formatDisplayDate(this.props.dates.minDate, true, true) }
+            { formatDisplayDate(timelineRangeParams.minDate, true, true) }
             {' '}
             &ndash;
-            { formatDisplayDate(this.props.dates.maxDate, true, true) }
+            { formatDisplayDate(timelineRangeParams.maxDate, true, true) }
           </div>
         </div>
         <div className="view-info-container">
@@ -260,10 +260,9 @@ class SummaryView extends React.PureComponent {
 
 const SummaryViewHOC = React.memo((props) => {
   const resources = useRecoilValue(resourcesState);
-  const timeFilters = useRecoilValue(timeFiltersState);
+  const timelineRangeParams = useRecoilValue(timelineRangeParamsState);
 
   const { legacy, categories, providers } = resources;
-  const { dates } = timeFilters;
 
   return (
     <SummaryView
@@ -271,7 +270,7 @@ const SummaryViewHOC = React.memo((props) => {
       resources={legacy}
       categories={categories}
       providers={providers}
-      dates={dates}
+      timelineRangeParams={timelineRangeParams}
     />
   );
 });

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -24,14 +24,13 @@ export const resourcesState = atom({
 const timeFilters = atom({
   key: 'timeFilters',
   default: {
-    dates: null,
-    // dates: {
-    //   allDates: null,
-    //   minDate: null,
-    //   startDate: null,
-    //   maxDate: null,
-    //   endDate: null,
-    // },
+    dates: {
+      allDates: null,
+      minDate: null,
+      maxDate: null,
+      startDate: null,
+      endDate: null,
+    },
     dateRangeStart: null,
     dateRangeEnd: null,
   },

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -29,7 +29,7 @@ export const timelineRangeParamsState = selector({
     const { legacy } = get(resourcesState);
 
     if (legacy) {
-      return computeFilterParams(legacy).dates;
+      return computeFilterParams(legacy);
     }
 
     return {

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -23,22 +23,6 @@ export const resourcesState = atom({
   // dangerouslyAllowMutability: true, // < Object.isExtensible(res.data), in: src/components/Annotation/index.js
 });
 
-export const allRecordIds = selector({
-  key: 'allRecordIds',
-  get: ({ get }) => {
-    const { records } = get(resourcesState);
-    // Return all record ids as an Array:
-    return Object.entries(records).reduce((acc, [uuid, record]) => {
-      if (record.category === 'Patient') {
-        console.info(`IGNORE PATIENT ${uuid}`); // eslint-disable-line no-console
-        return acc;
-      }
-      acc.push(uuid);
-      return acc;
-    }, []);
-  },
-});
-
 // from src/components/Unimplemented/index.js :
 const UNIMPLEMENTED_CATEGORIES = [
   'Practitioner', 'List', 'Questionnaire', 'Questionnaire Response', 'Observation-Other',

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -232,7 +232,7 @@ export const filteredActiveCollectionState = selector({
       }, {});
     filteredCategories.filteredRecordCount = totalFilteredRecordCount;
     filteredCategories.filteredCollectionCount = totalFilteredCollectionCount;
-    // console.info('groupedRecordIdsInCurrentCollectionState: ', JSON.stringify(filteredResults, null, '  '));
+    // console.info('filteredCategories: ', JSON.stringify(filteredCategories, null, '  '));
     return filteredCategories;
   },
 });

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -30,7 +30,8 @@ const UNIMPLEMENTED_CATEGORIES = [
   'Immunization Recommendation', 'Imaging Study', 'Coverage', 'Related Person', 'Device',
 ];
 
-export const groupedRecordIdsBySubtypeState = selector({
+// Computed once, and derived automatically from resourcesState, after API request:
+const groupedRecordIdsBySubtypeState = selector({
   key: 'groupedRecordIdsBySubtypeState',
   get: ({ get }) => {
     const { records } = get(resourcesState);

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -3,7 +3,7 @@ import {
 } from 'recoil';
 import jsonQuery from 'json-query';
 import { activeCategoriesState, activeProvidersState } from './category-provider-filters';
-import { computeFilterState } from '../utils/api';
+import { computeFilterParams } from '../utils/api';
 
 export * from './category-provider-filters';
 
@@ -29,7 +29,7 @@ export const timelineRangeParamsState = selector({
     const { legacy } = get(resourcesState);
 
     if (legacy) {
-      return computeFilterState(legacy).dates;
+      return computeFilterParams(legacy).dates;
     }
 
     return {

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -52,7 +52,21 @@ const timeFilters = atom({
 
 export const timeFiltersState = selector({
   key: 'timeFiltersState',
-  get: ({ get }) => get(timeFilters),
+  get: ({ get }) => {
+    const previousValues = get(timeFilters);
+    // console.info('timeFiltersState, previousValues: ', previousValues);
+    if (!previousValues.dateRangeStart) {
+      const { minDate, maxDate } = get(timelineRangeParamsState);
+      // console.info('timeFiltersState, minDate && maxDate: ', minDate, maxDate);
+      if (minDate && maxDate) {
+        return {
+          dateRangeStart: minDate.substring(0, 10),
+          dateRangeEnd: maxDate.substring(0, 10),
+        };
+      }
+    }
+    return previousValues;
+  },
   set: ({ get, set }, newValues) => {
     const previousValues = get(timeFilters);
     set(timeFilters, {

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -3,6 +3,7 @@ import {
 } from 'recoil';
 import jsonQuery from 'json-query';
 import { activeCategoriesState, activeProvidersState } from './category-provider-filters';
+import { computeFilterState } from '../utils/api';
 
 export * from './category-provider-filters';
 
@@ -21,16 +22,29 @@ export const resourcesState = atom({
   // dangerouslyAllowMutability: true, // < Object.isExtensible(res.data), in: src/components/Annotation/index.js
 });
 
+// Derived automatically, after API request:
+export const timelineRangeParamsState = selector({
+  key: 'timelineRangeParamsState',
+  get: ({ get }) => {
+    const { legacy } = get(resourcesState);
+
+    if (legacy) {
+      return computeFilterState(legacy).dates;
+    }
+
+    return {
+      allDates: null,
+      minDate: null,
+      startDate: null,
+      maxDate: null,
+      endDate: null,
+    };
+  },
+});
+
 const timeFilters = atom({
   key: 'timeFilters',
   default: {
-    dates: {
-      allDates: null,
-      minDate: null,
-      maxDate: null,
-      startDate: null,
-      endDate: null,
-    },
     dateRangeStart: null,
     dateRangeEnd: null,
   },

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -3,9 +3,10 @@ import {
 } from 'recoil';
 import jsonQuery from 'json-query';
 import { activeCategoriesState, activeProvidersState } from './category-provider-filters';
-import { computeFilterParams } from '../utils/api';
+import { timeFiltersState } from './time-filters';
 
 export * from './category-provider-filters';
+export * from './time-filters';
 
 export const resourcesState = atom({
   key: 'resourcesState', // unique ID (with respect to other atoms/selectors)
@@ -20,60 +21,6 @@ export const resourcesState = atom({
     legacy: null,
   },
   // dangerouslyAllowMutability: true, // < Object.isExtensible(res.data), in: src/components/Annotation/index.js
-});
-
-// Derived automatically, after API request:
-export const timelineRangeParamsState = selector({
-  key: 'timelineRangeParamsState',
-  get: ({ get }) => {
-    const { legacy } = get(resourcesState);
-
-    if (legacy) {
-      return computeFilterParams(legacy);
-    }
-
-    return {
-      allDates: null,
-      minDate: null,
-      startDate: null,
-      maxDate: null,
-      endDate: null,
-    };
-  },
-});
-
-const timeFilters = atom({
-  key: 'timeFilters',
-  default: {
-    dateRangeStart: null,
-    dateRangeEnd: null,
-  },
-});
-
-export const timeFiltersState = selector({
-  key: 'timeFiltersState',
-  get: ({ get }) => {
-    const previousValues = get(timeFilters);
-    // console.info('timeFiltersState, previousValues: ', previousValues);
-    if (!previousValues.dateRangeStart) {
-      const { minDate, maxDate } = get(timelineRangeParamsState);
-      // console.info('timeFiltersState, minDate && maxDate: ', minDate, maxDate);
-      if (minDate && maxDate) {
-        return {
-          dateRangeStart: minDate.substring(0, 10),
-          dateRangeEnd: maxDate.substring(0, 10),
-        };
-      }
-    }
-    return previousValues;
-  },
-  set: ({ get, set }, newValues) => {
-    const previousValues = get(timeFilters);
-    set(timeFilters, {
-      ...previousValues,
-      ...newValues,
-    });
-  },
 });
 
 export const allRecordIds = selector({

--- a/src/recoil/time-filters.js
+++ b/src/recoil/time-filters.js
@@ -1,0 +1,55 @@
+import { atom, selector } from 'recoil';
+import { computeFilterParams } from '../utils/api';
+import { resourcesState } from './index';
+
+// Computed once, and derived automatically from resourcesState, after API request:
+export const timelineRangeParamsState = selector({
+  key: 'timelineRangeParamsState',
+  get: ({ get }) => {
+    const { legacy } = get(resourcesState);
+
+    if (legacy) {
+      return computeFilterParams(legacy);
+    }
+
+    return {
+      allDates: null,
+      minDate: null,
+      startDate: null,
+      maxDate: null,
+      endDate: null,
+    };
+  },
+});
+
+const timeFilters = atom({
+  key: 'timeFilters',
+  default: {
+    dateRangeStart: null,
+    dateRangeEnd: null,
+  },
+});
+
+export const timeFiltersState = selector({
+  key: 'timeFiltersState',
+  get: ({ get }) => {
+    const previousValues = get(timeFilters);
+    if (!previousValues.dateRangeStart) {
+      const { minDate, maxDate } = get(timelineRangeParamsState);
+      if (minDate && maxDate) {
+        return {
+          dateRangeStart: minDate.substring(0, 10),
+          dateRangeEnd: maxDate.substring(0, 10),
+        };
+      }
+    }
+    return previousValues;
+  },
+  set: ({ get, set }, newValues) => {
+    const previousValues = get(timeFilters);
+    set(timeFilters, {
+      ...previousValues,
+      ...newValues,
+    });
+  },
+});

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -264,7 +264,7 @@ export const generateLegacyResources = (rawResponseData, normalizedResources, pa
   return legacyResources;
 };
 
-export const computeFilterState = (legacyResources) => {
+export const computeFilterParams = (legacyResources) => {
   const itemDates = cleanDates(legacyResources.pathItem('itemDate'));
 
   if (itemDates.length === 0) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -284,11 +284,7 @@ export const computeFilterParams = (legacyResources) => {
     allDates, minDate, startDate, maxDate, endDate,
   };
 
-  return {
-    dates,
-    dateRangeStart: minDate.substring(0, 10),
-    dateRangeEnd: maxDate.substring(0, 10),
-  };
+  return dates;
 };
 
 // Return sorted array of all provider names for this participant


### PR DESCRIPTION
* `timelineRangeParams` need only be computed once, per the lifetime of an API request

* `timelineRangeParamsState` is automatically derived from the API request state, without procedural code or within a component render

* the initial state of `timeFiltersState` is derived from `timelineRangeParamsState` (after `timelineRangeParamsState` is available)